### PR TITLE
ci: use cache to speed up build times (a bit)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo build --release
       - run: cargo test --release
       - run: cargo clippy -- -Dwarnings


### PR DESCRIPTION
Add usage of the `cache` action to save some 1m from the GH Action total execution time here.