### PR TITLE
Remove smallvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ tokio = { version = "1.35.1", features = ["sync", "macros", "rt", "time"] }
 trait-variant = "0.1.1"
 maybe-async = { version = "0.2" }
 async-trait = "0.1.77"
-smallvec = { version = "1.13.2", features = ["serde"] }
 curve25519-dalek = { version = "4.1.3", features = ["rand_core"] }
 
 ocelot = { git = "https://github.com/GaloisInc/swanky", rev = "154fa34" }

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -3,7 +3,6 @@
 use std::ops::{BitAnd, BitXor};
 
 use serde::{Deserialize, Serialize};
-use smallvec::SmallVec;
 
 /// The global key known only to a single party that is used to authenticate bits.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -94,7 +93,7 @@ impl Share {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct Auth(pub(crate) SmallVec<[(Mac, Key); 2]>);
+pub(crate) struct Auth(pub(crate) Vec<(Mac, Key)>);
 
 impl BitXor for &Auth {
     type Output = Auth;
@@ -102,7 +101,7 @@ impl BitXor for &Auth {
     fn bitxor(self, rhs: Self) -> Self::Output {
         let Auth(auth0) = self;
         let Auth(auth1) = rhs;
-        let mut xor = SmallVec::with_capacity(auth0.len());
+        let mut xor = Vec::with_capacity(auth0.len());
         for ((mac1, key1), (mac2, key2)) in auth0.iter().zip(auth1.iter()) {
             xor.push((*mac1 ^ *mac2, *key1 ^ *key2));
         }

--- a/src/faand.rs
+++ b/src/faand.rs
@@ -6,7 +6,6 @@ use rand::{random, Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use scuttlebutt::Block;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use smallvec::{smallvec, SmallVec};
 
 use crate::{
     channel::{self, recv_from, recv_vec_from, send_to, Channel},
@@ -459,7 +458,7 @@ async fn fabitn(
     }
     let mut res = Vec::with_capacity(l);
     for (l, xi) in x.iter().enumerate().take(l) {
-        let mut authvec = smallvec![(Mac(0), Key(0)); n];
+        let mut authvec = vec![(Mac(0), Key(0)); n];
         for k in (0..n).filter(|k| *k != i) {
             authvec[k] = (Mac(macs[k][l]), Key(keys[k][l]));
         }
@@ -686,7 +685,7 @@ async fn flaand(
     // Step 3) Compute z and e AND shares.
     let mut z = vec![false; l];
     let mut e = vec![false; l];
-    let mut zshares = vec![Share(false, Auth(smallvec![(Mac(0), Key(0)); n])); l];
+    let mut zshares = vec![Share(false, Auth(vec![(Mac(0), Key(0)); n])); l];
 
     for ll in 0..l {
         z[ll] = v[ll] ^ (xshares[ll].0 & yshares[ll].0);
@@ -783,7 +782,7 @@ pub(crate) fn bucket_size(circuit_size: usize) -> usize {
     }
 }
 
-type Bucket<'a> = SmallVec<[(&'a Share, &'a Share, &'a Share); 3]>;
+type Bucket<'a> = Vec<(&'a Share, &'a Share, &'a Share)>;
 
 /// Protocol Pi_aAND that performs F_aAND from the paper
 /// [Global-Scale Secure Multiparty Computation](https://dl.acm.org/doi/pdf/10.1145/3133956.3133979).
@@ -814,7 +813,7 @@ async fn faand(
         .collect();
 
     // Step 2) Randomly partition all objects into l buckets, each with b objects.
-    let mut buckets: Vec<Bucket> = vec![smallvec![]; l];
+    let mut buckets: Vec<Bucket> = vec![vec![]; l];
 
     for obj in triples {
         let mut j = shared_rand.gen_range(0..l);
@@ -983,7 +982,7 @@ async fn check_dvalue(
 fn combine_bucket(
     i: usize,
     n: usize,
-    bucket: SmallVec<[(&Share, &Share, &Share); 3]>,
+    bucket: Vec<(&Share, &Share, &Share)>,
     d_vec: Vec<bool>,
 ) -> Result<(Share, Share, Share), Error> {
     let mut bucket = bucket.into_iter();
@@ -1010,7 +1009,7 @@ fn combine_two_leaky_ands(
 ) -> Result<(Share, Share, Share), Error> {
     //Step (b) compute x, y, z.
     let xbit = x1.0 ^ x2.0;
-    let mut xauth = Auth(smallvec![(Mac(0), Key(0)); n]);
+    let mut xauth = Auth(vec![(Mac(0), Key(0)); n]);
     for k in (0..n).filter(|k| *k != i) {
         let (mk_x1, ki_x1) = x1.1 .0[k];
         let (mk_x2, ki_x2) = x2.1 .0[k];
@@ -1019,7 +1018,7 @@ fn combine_two_leaky_ands(
     let xshare = Share(xbit, xauth);
 
     let zbit = z1.0 ^ z2.0 ^ d & x2.0;
-    let mut zauth = Auth(smallvec![(Mac(0), Key(0)); n]);
+    let mut zauth = Auth(vec![(Mac(0), Key(0)); n]);
     for k in (0..n).filter(|k| *k != i) {
         let (mk_z1, ki_z1) = z1.1 .0[k];
         let (mk_z2, ki_z2) = z2.1 .0[k];

--- a/src/fpre.rs
+++ b/src/fpre.rs
@@ -326,8 +326,7 @@ mod tests {
                 assert_eq!(mac_s3, key_s3 ^ (s3 & delta_a));
             } else if i == 1 {
                 // corrupted (r1 XOR s1) AND (r2 XOR s2):
-                let auth_r1_corrupted =
-                    Share(!r1, Auth(vec![(Mac(0), Key(0)), (mac_r1, key_s1)]));
+                let auth_r1_corrupted = Share(!r1, Auth(vec![(Mac(0), Key(0)), (mac_r1, key_s1)]));
                 send_to(
                     &mut a,
                     fpre_party,

--- a/src/fpre.rs
+++ b/src/fpre.rs
@@ -2,7 +2,6 @@
 
 use maybe_async::maybe_async;
 use rand::random;
-use smallvec::smallvec;
 
 use crate::{
     channel::{self, recv_from, send_to, Channel},
@@ -89,7 +88,7 @@ pub(crate) async fn fpre(channel: &mut (impl Channel + Send), parties: usize) ->
             }
         }
         for i in 0..parties {
-            let mut mac_and_key = smallvec![(Mac(0), Key(0)); parties];
+            let mut mac_and_key = vec![(Mac(0), Key(0)); parties];
             for j in 0..parties {
                 if i != j {
                     let mac = keys[j][i] ^ (bits[i] & deltas[j]);
@@ -179,7 +178,7 @@ pub(crate) async fn fpre(channel: &mut (impl Channel + Send), parties: usize) ->
             }
         }
         for i in 0..parties {
-            let mut mac_and_key = smallvec![(Mac(0), Key(0)); parties];
+            let mut mac_and_key = vec![(Mac(0), Key(0)); parties];
             for j in 0..parties {
                 if i != j {
                     let mac = keys[j][i] ^ (bits[i] & deltas[j]);
@@ -204,7 +203,6 @@ mod tests {
         protocol::{Preprocessor, _mpc},
     };
     use garble_lang::{circuit::Circuit, compile};
-    use smallvec::smallvec;
 
     #[tokio::test]
     async fn xor_homomorphic_mac() -> Result<(), Error> {
@@ -329,7 +327,7 @@ mod tests {
             } else if i == 1 {
                 // corrupted (r1 XOR s1) AND (r2 XOR s2):
                 let auth_r1_corrupted =
-                    Share(!r1, Auth(smallvec![(Mac(0), Key(0)), (mac_r1, key_s1)]));
+                    Share(!r1, Auth(vec![(Mac(0), Key(0)), (mac_r1, key_s1)]));
                 send_to(
                     &mut a,
                     fpre_party,
@@ -351,7 +349,7 @@ mod tests {
                 let mac_r1_corrupted = key_r1 ^ (!r1 & delta_b);
                 let auth_r1_corrupted = Share(
                     !r1,
-                    Auth(smallvec![(Mac(0), Key(0)), (mac_r1_corrupted, key_s1)]),
+                    Auth(vec![(Mac(0), Key(0)), (mac_r1_corrupted, key_s1)]),
                 );
                 send_to(
                     &mut a,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -37,7 +37,6 @@ use garble_lang::circuit::{Circuit, CircuitError, Wire};
 use maybe_async::maybe_async;
 use rand::{random, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use smallvec::smallvec;
 
 use crate::{
     channel::{self, recv_from, recv_vec_from, send_to, Channel},
@@ -303,7 +302,7 @@ pub(crate) async fn _mpc(
     }
 
     let mut random_shares = random_shares.into_iter();
-    let mut shares = vec![Share(false, Auth(smallvec![])); num_gates];
+    let mut shares = vec![Share(false, Auth(vec![])); num_gates];
     let mut labels = vec![Label(0); num_gates];
 
     for (w, gate) in circuit.wires().iter().enumerate() {


### PR DESCRIPTION
Removed SmallVec to make panic freedom checking simpler, since SmallVec only brings a minor improvement for 2 parties.