### PR TITLE
Add tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 serde = { version = "1.0.195", features = ["derive"] }
 tokio = { version = "1.35.1", features = ["sync", "macros", "rt", "time"] }
+tracing = "0.1.41"
 trait-variant = "0.1.1"
 maybe-async = { version = "0.2" }
 async-trait = "0.1.77"


### PR DESCRIPTION
This adds the tracing crate and changes the println! in the SimpleChannel impl to use trace instead. This should lead to less insignificant output in the benchmarks.

A follow-up PR should add more `instrument` annotations as described in #65.