### PR TITLE
Add bench workflow for main branch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,7 +2,7 @@ name: bench
 
 on:
   push:
-    branches: 
+    branches:
       - "main"
   workflow_dispatch:
     inputs:
@@ -17,7 +17,8 @@ on:
 
 jobs:
   benchmarks:
-    runs-on: "ubuntu-latest"
+    timeout-minutes: 30
+    runs-on: "ubicloud-standard-4-ubuntu-2404"
     env:
       CRITERION_HOME: ${{ github.workspace }}/.criterion_data
     steps:
@@ -30,9 +31,9 @@ jobs:
       - name: CPU information
         run: lscpu
       - name: Cache compilation
-        uses: swatinem/rust-cache@v2
+        uses: ubicloud/rust-cache@v2
       - name: Cache criterion
-        uses: actions/cache@v4
+        uses: ubicloud/cache@v4
         with:
           path: ${{ env.CRITERION_HOME }}
           key: ${{ runner.os }}-${{ runner.arch }}-criterion-data


### PR DESCRIPTION
This workflow runs the benchmark on pushed to the main branch or when manually triggered. A manual run can specify a git ref and a criterion filter.

Currently, the benchmarks run on the free Github provided runners. This is not ideal, as these runners are slow and have unreliable performance. In my [own project](https://github.com/robinhundt/CryProt/blob/main/.github/workflows/bench.yml) I use the runners provided by [Ubicloud](https://www.ubicloud.com/docs/github-actions-integration/quickstart).
They are hosted on the Hetzner Cloud, reasonably fast and provide acceptable performance reliability. 
The [pricing](https://www.ubicloud.com/docs/about/pricing#github-actions) is 10x cheaper than the paid runners on Github at a better performance. 1$ of Action minutes is free per month, which equates to 1250 minutes of the smallest runner. If we only use these runners for the benchmarks, we might even stay under that.
If we're happy with the runners for the benchmarks, we could also think about using them for all CI workflows to increase their performance (see #67).
One drawback of ubicloud is that afaik they have no way of enforcing spending limits. This is sadly something many cloud providers have in common...

Another thing I'd like to add is tracking of benchmark results via https://bencher.dev/. This service would allow us to nicely track the benchmark results over time, with automatically generated plots. For public projects, this is even free. An example of how this could look is [here](https://bencher.dev/perf/cryprot/plots). One open question is whether bencher can parse the output of our custom memory measurements.

@kisakishy and @zeitgeist what do you think about using these services for the benchmarks?

