### PR TITLE
Channel use shared ref in recv bytes

### DIFF
--- a/docs/src/examples/channel.md
+++ b/docs/src/examples/channel.md
@@ -41,7 +41,7 @@ trait Channel {
     ) -> Result<(), Self::SendError>;
 
     async fn recv_bytes_from(
-        &mut self,
+        &self,
         p: usize,
         info: RecvInfo,
     ) -> Result<Vec<u8>, Self::RecvError>;

--- a/docs/src/examples/http_multi.md
+++ b/docs/src/examples/http_multi.md
@@ -19,7 +19,7 @@ The following example shows how to implement a `Channel` trait using HTTP commun
 struct HttpChannel {
     urls: Vec<Url>,
     party: usize,
-    recv: Vec<Receiver<Vec<u8>>>,
+    recv: Vec<Mutex<Receiver<Vec<u8>>>>,
 }
 
 impl HttpChannel {
@@ -59,15 +59,13 @@ impl Channel for HttpChannel {
         }
     }
 
-    async fn recv_bytes_from(
-        &self,
-        p: usize,
-        _info: RecvInfo,
-    ) -> Result<Vec<u8>, Self::RecvError> {
-        Ok(timeout(Duration::from_secs(1), self.recv[p].recv())
+    async fn recv_bytes_from(&self, p: usize, _info: RecvInfo) -> Result<Vec<u8>, Self::RecvError> {
+        let mut r = self.recv[p].lock().await;
+        Ok(timeout(Duration::from_secs(1), r.recv())
             .await
             .context("recv_bytes_from({p})")?
             .unwrap_or_default())
     }
 }
+
 ```

--- a/docs/src/examples/http_multi.md
+++ b/docs/src/examples/http_multi.md
@@ -60,7 +60,7 @@ impl Channel for HttpChannel {
     }
 
     async fn recv_bytes_from(
-        &mut self,
+        &self,
         p: usize,
         _info: RecvInfo,
     ) -> Result<Vec<u8>, Self::RecvError> {

--- a/docs/src/examples/http_single.md
+++ b/docs/src/examples/http_single.md
@@ -41,7 +41,7 @@ impl Channel for PollingHttpChannel {
     }
 
     async fn recv_bytes_from(
-        &mut self,
+        &self,
         p: usize,
         _info: RecvInfo,
     ) -> Result<Vec<u8>, HttpChannelError> {

--- a/docs/src/examples/iroh.md
+++ b/docs/src/examples/iroh.md
@@ -11,8 +11,8 @@ The core part of the example is the `IrohChannel`, which implements Polytune's `
 ```rust
 struct IrohChannel {
     sender: GossipSender,
-    receiver: GossipReceiver,
-    received_msgs: HashMap<usize, VecDeque<Vec<u8>>>,
+    receiver: tokio::sync::Mutex<GossipReceiver>,
+    received_msgs: Mutex<HashMap<usize, VecDeque<Vec<u8>>>>,
     party: usize,
 }
 
@@ -37,20 +37,22 @@ impl Channel for IrohChannel {
         Ok(())
     }
 
-    async fn recv_bytes_from(
-        &self,
-        p: usize,
-        _info: RecvInfo,
-    ) -> Result<Vec<u8>, Self::RecvError> {
+    // TODO this implementation seems really dubious to me... I'm really not sure if it behaves
+    //  correctly in edge-cases
+    async fn recv_bytes_from(&self, p: usize, _info: RecvInfo) -> Result<Vec<u8>, Self::RecvError> {
         tracing::info!("receiving message from {p}");
-        if let Some(msgs) = self.received_msgs.get_mut(&p) {
-            if let Some(msg) = msgs.pop_front() {
-                tracing::info!("found stored message from {p}");
-                return Ok(msg);
+        {
+            let mut msgs_lock = self.received_msgs.lock().expect("poisoned");
+            if let Some(msgs) = msgs_lock.get_mut(&p) {
+                if let Some(msg) = msgs.pop_front() {
+                    tracing::info!("found stored message from {p}");
+                    return Ok(msg);
+                }
             }
         }
         tracing::info!("could not find stored message, waiting for message...");
-        while let Some(event) = self.receiver.try_next().await? {
+        let mut receiver = self.receiver.lock().await;
+        while let Some(event) = receiver.try_next().await? {
             if let Event::Gossip(GossipEvent::Received(msg)) = event {
                 let msg: Message = postcard::from_bytes(&msg.content)?;
                 if msg.to_party == self.party {
@@ -64,6 +66,8 @@ impl Channel for IrohChannel {
                             msg.from_party,
                         );
                         self.received_msgs
+                            .lock()
+                            .expect("poisoned")
                             .entry(msg.from_party)
                             .or_default()
                             .push_back(msg.data);

--- a/docs/src/examples/iroh.md
+++ b/docs/src/examples/iroh.md
@@ -38,7 +38,7 @@ impl Channel for IrohChannel {
     }
 
     async fn recv_bytes_from(
-        &mut self,
+        &self,
         p: usize,
         _info: RecvInfo,
     ) -> Result<Vec<u8>, Self::RecvError> {

--- a/docs/src/examples/wasm.md
+++ b/docs/src/examples/wasm.md
@@ -62,7 +62,7 @@ impl Channel for HttpChannel {
     }
 
     async fn recv_bytes_from(
-        &mut self,
+        &self,
         p: usize,
         _info: RecvInfo,
     ) -> Result<Vec<u8>, Self::RecvError> {

--- a/examples/api-integration/src/main.rs
+++ b/examples/api-integration/src/main.rs
@@ -408,11 +408,7 @@ impl Channel for HttpChannel {
         }
     }
 
-    async fn recv_bytes_from(
-        &mut self,
-        p: usize,
-        _info: RecvInfo,
-    ) -> Result<Vec<u8>, Self::RecvError> {
+    async fn recv_bytes_from(&self, p: usize, _info: RecvInfo) -> Result<Vec<u8>, Self::RecvError> {
         timeout(Duration::from_secs(30 * 60), self.recv[p].recv())
             .await
             .context(format!("recv_bytes_from(p = {p})"))?

--- a/examples/api-integration/src/main.rs
+++ b/examples/api-integration/src/main.rs
@@ -223,7 +223,7 @@ async fn execute_mpc(state: MpcState, policy: &Policy) -> Result<Option<Literal>
         for _ in 0..policy.participants.len() {
             let (s, r) = channel(1);
             state.senders.push(s);
-            receivers.push(r);
+            receivers.push(Mutex::new(r));
         }
 
         HttpChannel {
@@ -362,7 +362,7 @@ async fn msg(State(state): State<MpcState>, Path(from): Path<u32>, body: Bytes) 
 struct HttpChannel {
     urls: Vec<Url>,
     party: usize,
-    recv: Vec<Receiver<Vec<u8>>>,
+    recv: Vec<Mutex<Receiver<Vec<u8>>>>,
 }
 
 impl Channel for HttpChannel {
@@ -409,7 +409,8 @@ impl Channel for HttpChannel {
     }
 
     async fn recv_bytes_from(&self, p: usize, _info: RecvInfo) -> Result<Vec<u8>, Self::RecvError> {
-        timeout(Duration::from_secs(30 * 60), self.recv[p].recv())
+        let mut r = self.recv[p].lock().await;
+        timeout(Duration::from_secs(30 * 60), r.recv())
             .await
             .context(format!("recv_bytes_from(p = {p})"))?
             .ok_or_else(|| anyhow!("Expected a message, but received `None`!"))

--- a/examples/http-multi-server-channels/src/main.rs
+++ b/examples/http-multi-server-channels/src/main.rs
@@ -130,11 +130,7 @@ impl Channel for HttpChannel {
         }
     }
 
-    async fn recv_bytes_from(
-        &mut self,
-        p: usize,
-        _info: RecvInfo,
-    ) -> Result<Vec<u8>, Self::RecvError> {
+    async fn recv_bytes_from(&self, p: usize, _info: RecvInfo) -> Result<Vec<u8>, Self::RecvError> {
         Ok(timeout(Duration::from_secs(1), self.recv[p].recv())
             .await
             .context("recv_bytes_from({p})")?

--- a/examples/http-single-server-channels/src/http_channel.rs
+++ b/examples/http-single-server-channels/src/http_channel.rs
@@ -74,7 +74,7 @@ impl Channel for PollingHttpChannel {
     }
 
     async fn recv_bytes_from(
-        &mut self,
+        &self,
         p: usize,
         _info: RecvInfo,
     ) -> Result<Vec<u8>, HttpChannelError> {

--- a/examples/iroh-p2p-channels/src/main.rs
+++ b/examples/iroh-p2p-channels/src/main.rs
@@ -203,11 +203,7 @@ impl Channel for IrohChannel {
         Ok(())
     }
 
-    async fn recv_bytes_from(
-        &mut self,
-        p: usize,
-        _info: RecvInfo,
-    ) -> Result<Vec<u8>, Self::RecvError> {
+    async fn recv_bytes_from(&self, p: usize, _info: RecvInfo) -> Result<Vec<u8>, Self::RecvError> {
         tracing::info!("receiving message from {p}");
         if let Some(msgs) = self.received_msgs.get_mut(&p) {
             if let Some(msg) = msgs.pop_front() {

--- a/examples/iroh-p2p-channels/tests/cli.rs
+++ b/examples/iroh-p2p-channels/tests/cli.rs
@@ -9,8 +9,9 @@ fn simulate() {
     let mut cmd = Command::new("cargo")
         .args([
             "run",
-            // "--release",
+            "--release",
             "--",
+            "--wait-time=1",
             "--program=.add.garble.rs",
             "--party=2",
             "--input=2",
@@ -43,8 +44,9 @@ fn simulate() {
     let mut cmd = Command::new("cargo")
         .args([
             "run",
-            // "--release",
+            "--release",
             "--",
+            "--wait-time=1",
             "--program=.add.garble.rs",
             "--party=1",
             "--input=2",
@@ -70,8 +72,9 @@ fn simulate() {
     let out = Command::new("cargo")
         .args([
             "run",
-            // "--release",
+            "--release",
             "--",
+            "--wait-time=1",
             "--program=.add.garble.rs",
             "--party=0",
             "--input=2",

--- a/examples/sql-integration/src/main.rs
+++ b/examples/sql-integration/src/main.rs
@@ -715,11 +715,7 @@ impl Channel for HttpChannel {
         }
     }
 
-    async fn recv_bytes_from(
-        &mut self,
-        p: usize,
-        _info: RecvInfo,
-    ) -> Result<Vec<u8>, Self::RecvError> {
+    async fn recv_bytes_from(&self, p: usize, _info: RecvInfo) -> Result<Vec<u8>, Self::RecvError> {
         timeout(Duration::from_secs(30 * 60), self.recv[p].recv())
             .await
             .context(format!("recv_bytes_from(p = {p})"))?

--- a/examples/wasm-http-channels/src/lib.rs
+++ b/examples/wasm-http-channels/src/lib.rs
@@ -83,11 +83,7 @@ impl Channel for HttpChannel {
         return Err(format!("Could not reach {url}"));
     }
 
-    async fn recv_bytes_from(
-        &mut self,
-        p: usize,
-        _info: RecvInfo,
-    ) -> Result<Vec<u8>, Self::RecvError> {
+    async fn recv_bytes_from(&self, p: usize, _info: RecvInfo) -> Result<Vec<u8>, Self::RecvError> {
         let client = reqwest::Client::new();
         let url = format!("{}recv/{}/{}", self.url, self.party, p);
         for _ in 0..50 {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -161,7 +161,7 @@ pub trait Channel {
     /// Awaits a response from the party with the given index (must be between `0..participants`).
     #[allow(async_fn_in_trait)]
     async fn recv_bytes_from(
-        &mut self,
+        &self,
         party: usize,
         info: RecvInfo,
     ) -> Result<Vec<u8>, Self::RecvError>;
@@ -352,11 +352,7 @@ impl Channel for SimpleChannel {
     }
 
     #[tracing::instrument(level = Level::TRACE, skip(self), fields(info = ?_info))]
-    async fn recv_bytes_from(
-        &mut self,
-        p: usize,
-        _info: RecvInfo,
-    ) -> Result<Vec<u8>, AsyncRecvError> {
+    async fn recv_bytes_from(&self, p: usize, _info: RecvInfo) -> Result<Vec<u8>, AsyncRecvError> {
         let chunk = self.r[p]
             .as_mut()
             .unwrap_or_else(|| panic!("No receiver for party {p}"))


### PR DESCRIPTION
Follow up PR to #106 and closes #87.

I've intentionally changed the channel implementation in a non-ideal way to keep this PR smallish. A follow up PR should look closer at the current channel implementation. I'm especially unsure whether the iroh implementation would behave correctly in edge-cases.