### PR TITLE
61 sequential sending/receiving to parties with potential deadlocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,6 +3163,7 @@ dependencies = [
  "cpufeatures",
  "criterion",
  "curve25519-dalek",
+ "futures",
  "garble_lang",
  "getrandom 0.2.16",
  "getrandom 0.3.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ bincode = "1.3.3"
 blake3 = "1.5.0"
 bytemuck = { version = "1.23.1", features = ["latest_stable_rust"] }
 chacha20poly1305 = "0.10.1"
+futures = { version = "0.3.31", default-features = false, features = ["alloc"] }
 garble_lang = { version = "0.6.1", features = ["serde"] }
 rand = "0.9.1"
 rand_core_0_6 = { package = "rand_core", version = "0.6" }

--- a/benches/join.rs
+++ b/benches/join.rs
@@ -34,16 +34,7 @@ async fn simulate_mpc_async(
         let inputs = inputs.to_vec();
         let output_parties = output_parties.to_vec();
         computation.spawn(async move {
-            match mpc(
-                &channel,
-                &circuit,
-                &inputs,
-                p_eval,
-                p_own,
-                &output_parties,
-            )
-            .await
-            {
+            match mpc(&channel, &circuit, &inputs, p_eval, p_own, &output_parties).await {
                 Ok(res) => {
                     info!(
                         "Party {p_own} sent {:.2}MB of messages",

--- a/benches/join.rs
+++ b/benches/join.rs
@@ -24,18 +24,18 @@ async fn simulate_mpc_async(
     let channels = channel::SimpleChannel::channels(inputs.len());
 
     let mut parties = channels.into_iter().zip(inputs).enumerate();
-    let Some((_, (mut eval_channel, inputs))) = parties.next() else {
+    let Some((_, (eval_channel, inputs))) = parties.next() else {
         return Ok(vec![]);
     };
 
     let mut computation: tokio::task::JoinSet<Vec<bool>> = tokio::task::JoinSet::new();
-    for (p_own, (mut channel, inputs)) in parties {
+    for (p_own, (channel, inputs)) in parties {
         let circuit = circuit.clone();
         let inputs = inputs.to_vec();
         let output_parties = output_parties.to_vec();
         computation.spawn(async move {
             match mpc(
-                &mut channel,
+                &channel,
                 &circuit,
                 &inputs,
                 p_eval,
@@ -59,7 +59,7 @@ async fn simulate_mpc_async(
         });
     }
     let eval_result = mpc(
-        &mut eval_channel,
+        &eval_channel,
         circuit,
         inputs,
         p_eval,

--- a/benches/mpc.rs
+++ b/benches/mpc.rs
@@ -146,7 +146,7 @@ fn bench_circuit_two_parties<'a, M, F>(
             let mut validate_output = validate_output.clone();
             let mut elapsed = M::Value::default();
             for _ in 0..iters {
-                let [mut ch1, mut ch2] = channel::SimpleChannel::channels(2)
+                let [ch1, ch2] = channel::SimpleChannel::channels(2)
                     .try_into()
                     .expect("parties is 2");
                 let circ1 = circ.clone();
@@ -160,7 +160,7 @@ fn bench_circuit_two_parties<'a, M, F>(
                 // this means that we must recreate the SimpleChannel and circ above, because the future needs to
                 // be 'static for spawning.
                 let fut = async move {
-                    mpc(&mut ch1, &circ1, &inputs1, 0, 0, &p_out)
+                    mpc(&ch1, &circ1, &inputs1, 0, 0, &p_out)
                         .await
                         .expect("mpc execution failed")
                 };
@@ -172,7 +172,7 @@ fn bench_circuit_two_parties<'a, M, F>(
                     tx.send(res).expect("channel closed");
                 });
                 let fut = async move {
-                    mpc(&mut ch2, &circ2, &inputs2, 0, 1, &p_out)
+                    mpc(&ch2, &circ2, &inputs2, 0, 1, &p_out)
                         .await
                         .expect("mpc execution failed")
                 };

--- a/benches/primitives.rs
+++ b/benches/primitives.rs
@@ -34,7 +34,7 @@ fn bench_ots<'a>(
             // iter_custom allows us to do the setup here without impacting the tracked time
             // doing the setup in primitives_benchmark is tricky/not possible due to the
             // future capturing &mut variables
-            let [mut ch1, mut ch2] = channel::SimpleChannel::channels(2)
+            let [ch1, ch2] = channel::SimpleChannel::channels(2)
                 .try_into()
                 .expect("parties is 2");
             let mut shared_rand1 = ChaCha20Rng::seed_from_u64(42);
@@ -46,8 +46,8 @@ fn bench_ots<'a>(
                 let now = Instant::now();
                 for _ in 0..iters {
                     tokio::try_join!(
-                        kos_ot_sender(&mut ch1, &deltas, 1, &mut shared_rand1),
-                        kos_ot_receiver(&mut ch2, &bs, 0, &mut shared_rand2)
+                        kos_ot_sender(&ch1, &deltas, 1, &mut shared_rand1),
+                        kos_ot_receiver(&ch2, &bs, 0, &mut shared_rand2)
                     )
                     .expect("OTs failed");
                 }

--- a/docs/src/protocol.md
+++ b/docs/src/protocol.md
@@ -14,7 +14,7 @@ Our implementation of WRK17 provides the `mpc` function for executing MPC comput
 
 ```rust
 pub async fn mpc(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     circuit: &Circuit,
     inputs: &[bool],
     p_fpre: Preprocessor,

--- a/examples/api-integration/src/main.rs
+++ b/examples/api-integration/src/main.rs
@@ -213,7 +213,7 @@ async fn execute_mpc(state: MpcState, policy: &Policy) -> Result<Option<Literal>
 
     // Now that we have our input, we can start the actual session:
     let p_out: Vec<_> = vec![*leader];
-    let mut channel = {
+    let channel = {
         let mut locked = state.lock().await;
         let state = locked.borrow_mut();
         if !state.senders.is_empty() {
@@ -234,7 +234,7 @@ async fn execute_mpc(state: MpcState, policy: &Policy) -> Result<Option<Literal>
     };
 
     // We run the computation using MPC, which might take some time...
-    let output = mpc(&mut channel, &prg.circuit, &input, 0, *party, &p_out).await?;
+    let output = mpc(&channel, &prg.circuit, &input, 0, *party, &p_out).await?;
 
     // ...and now we are done and return the output (if there is any):
     state.lock().await.senders.clear();

--- a/examples/http-multi-server-channels/src/main.rs
+++ b/examples/http-multi-server-channels/src/main.rs
@@ -54,8 +54,8 @@ async fn main() -> Result<(), Error> {
     let prg = compile(&code).map_err(|e| anyhow!(e.prettify(&code)))?;
     let input = prg.parse_arg(party, &input)?.as_bits();
     let p_out: Vec<_> = (0..urls.len()).collect();
-    let mut channel = HttpChannel::new(urls, party).await?;
-    let output = mpc(&mut channel, &prg.circuit, &input, 0, party, &p_out).await?;
+    let channel = HttpChannel::new(urls, party).await?;
+    let output = mpc(&channel, &prg.circuit, &input, 0, party, &p_out).await?;
     if !output.is_empty() {
         println!("\nThe result is {}", prg.parse_output(&output)?);
     }

--- a/examples/http-single-server-channels/src/main.rs
+++ b/examples/http-single-server-channels/src/main.rs
@@ -61,7 +61,7 @@ async fn main() {
             let prg = compile(&prg).unwrap();
             let input = prg.parse_arg(party, &input).unwrap().as_bits();
             let p_eval = 0;
-            let mut channel = PollingHttpChannel::new(&url, &session, party);
+            let channel = PollingHttpChannel::new(&url, &session, party);
             channel.join().await.unwrap();
             let parties = prg.circuit.input_gates.len();
             loop {
@@ -74,7 +74,7 @@ async fn main() {
                 }
             }
             let p_out: Vec<_> = (0..parties).collect();
-            let output = mpc(&mut channel, &prg.circuit, &input, p_eval, party, &p_out)
+            let output = mpc(&channel, &prg.circuit, &input, p_eval, party, &p_out)
                 .await
                 .unwrap();
             if !output.is_empty() {

--- a/examples/iroh-p2p-channels/src/main.rs
+++ b/examples/iroh-p2p-channels/src/main.rs
@@ -158,7 +158,7 @@ async fn main() -> Result<()> {
     sleep(Duration::from_secs(args.wait_time)).await;
     println!("> starting the computation...");
 
-    let mut channel = IrohChannel {
+    let channel = IrohChannel {
         sender,
         receiver: tokio::sync::Mutex::new(receiver),
         received_msgs: Mutex::default(),
@@ -169,7 +169,7 @@ async fn main() -> Result<()> {
     let p_own = args.party;
     let p_out: Vec<_> = (0..parties).collect();
 
-    let output = mpc(&mut channel, &prg.circuit, &input, p_eval, p_own, &p_out).await?;
+    let output = mpc(&channel, &prg.circuit, &input, p_eval, p_own, &p_out).await?;
 
     // shutdown
     router.shutdown().await?;

--- a/examples/sql-integration/src/main.rs
+++ b/examples/sql-integration/src/main.rs
@@ -535,7 +535,7 @@ async fn execute_mpc(
 
     // Now that we have our input, we can start the actual session without a trusted third party:
     let p_out: Vec<_> = vec![*leader];
-    let mut channel = {
+    let channel = {
         let mut locked = state.lock().await;
         let state = locked.borrow_mut();
         if !state.senders.is_empty() {
@@ -556,7 +556,7 @@ async fn execute_mpc(
     };
 
     // We run the computation using MPC, which might take some time...
-    let output = mpc(&mut channel, &prg.circuit, &input, 0, *party, &p_out).await?;
+    let output = mpc(&channel, &prg.circuit, &input, 0, *party, &p_out).await?;
 
     // ...and now we are done and return the output (if there is any):
     state.lock().await.senders.clear();

--- a/examples/wasm-http-channels/src/lib.rs
+++ b/examples/wasm-http-channels/src/lib.rs
@@ -26,8 +26,8 @@ pub async fn compute(url: String, party: usize, input: i32, range: u32) -> Resul
         .map_err(|e| format!("Invalid i32 input: {e}"))?
         .as_bits();
     let p_out = vec![0, 1, 2];
-    let mut channel = HttpChannel::new(url, party).await?;
-    let output = mpc(&mut channel, &prg.circuit, &input, 0, party, &p_out)
+    let channel = HttpChannel::new(url, party).await?;
+    let output = mpc(&channel, &prg.circuit, &input, 0, party, &p_out)
         .await
         .map_err(|e| format!("MPC computation failed: {e}"))?;
     let output = prg

--- a/src/bench_reexports.rs
+++ b/src/bench_reexports.rs
@@ -14,7 +14,7 @@ use rand_chacha::ChaCha20Rng;
 use crate::{channel::Channel, faand::Error, ot};
 
 pub async fn kos_ot_sender(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     deltas: &[Block],
     p_to: usize,
     shared_rand: &mut ChaCha20Rng,
@@ -23,7 +23,7 @@ pub async fn kos_ot_sender(
 }
 
 pub async fn kos_ot_receiver(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     bs: &[bool],
     p_to: usize,
     shared_rand: &mut ChaCha20Rng,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -172,7 +172,7 @@ pub trait Channel {
 
 /// Serializes and sends an MPC message to the other party.
 pub(crate) async fn send_to<S: Serialize + std::fmt::Debug>(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     party: usize,
     phase: &str,
     msg: &[S],
@@ -211,7 +211,7 @@ pub(crate) async fn send_to<S: Serialize + std::fmt::Debug>(
 
 /// Receives and deserializes an MPC message from the other party.
 pub(crate) async fn recv_from<T: DeserializeOwned + std::fmt::Debug>(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     party: usize,
     phase: &str,
 ) -> Result<Vec<T>, Error> {
@@ -249,7 +249,7 @@ pub(crate) async fn recv_from<T: DeserializeOwned + std::fmt::Debug>(
 
 /// Receives and deserializes a Vec from the other party (while checking the length).
 pub(crate) async fn recv_vec_from<T: DeserializeOwned + std::fmt::Debug>(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     party: usize,
     phase: &str,
     len: usize,

--- a/src/faand.rs
+++ b/src/faand.rs
@@ -105,7 +105,7 @@ pub(crate) fn hash_vec<T: Serialize>(data: &Vec<T>) -> Result<u128, Error> {
 pub(crate) async fn broadcast_verification<
     T: Clone + Serialize + DeserializeOwned + std::fmt::Debug + PartialEq,
 >(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     i: usize,
     n: usize,
     phase: &str,
@@ -160,7 +160,7 @@ pub(crate) async fn broadcast_verification<
 pub(crate) async fn broadcast<
     T: Clone + Serialize + DeserializeOwned + std::fmt::Debug + PartialEq,
 >(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     i: usize,
     n: usize,
     phase: &str,
@@ -187,7 +187,7 @@ pub(crate) async fn broadcast_first_send_second<
     T: Clone + Serialize + DeserializeOwned + std::fmt::Debug + PartialEq,
     S: Clone + Serialize + DeserializeOwned + std::fmt::Debug + PartialEq,
 >(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     i: usize,
     n: usize,
     phase: &str,
@@ -220,7 +220,7 @@ pub(crate) async fn broadcast_first_send_second<
 /// a final shared random seed. This shared seed is then used to create a `ChaCha20Rng`, a
 /// cryptographically secure random number generator.
 pub(crate) async fn shared_rng(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     i: usize,
     n: usize,
 ) -> Result<ChaCha20Rng, Error> {
@@ -274,7 +274,7 @@ pub(crate) async fn shared_rng(
 /// This function generates a shared random number generator (RNG) between every two parties using
 /// two-party coin tossing for the two-party KOS OT protocol.
 pub(crate) async fn shared_rng_pairwise(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     i: usize,
     n: usize,
 ) -> Result<Vec<Vec<Option<ChaCha20Rng>>>, Error> {
@@ -348,7 +348,7 @@ pub(crate) async fn shared_rng_pairwise(
 /// of a linear combination of the bits, keys and the MACs and then removing 2 * RHO objects,
 /// where RHO is the statistical security parameter.
 async fn fabitn(
-    (channel, delta): (&mut impl Channel, Delta),
+    (channel, delta): (&impl Channel, Delta),
     i: usize,
     n: usize,
     l: usize,
@@ -474,7 +474,7 @@ async fn fabitn(
 ///      MACs against the commitments.
 /// 4. **Return Shares**: Finally, the function returns the first `l` authenticated bit shares.
 pub(crate) async fn fashare(
-    (channel, delta): (&mut impl Channel, Delta),
+    (channel, delta): (&impl Channel, Delta),
     i: usize,
     n: usize,
     l: usize,
@@ -581,7 +581,7 @@ pub(crate) async fn fashare(
 /// The XOR of xiyj values are generated obliviously, which is half of the z value in an
 /// authenticated share, i.e., a half-authenticated share.
 async fn fhaand(
-    (channel, delta): (&mut impl Channel, Delta),
+    (channel, delta): (&impl Channel, Delta),
     i: usize,
     n: usize,
     l: usize,
@@ -656,7 +656,7 @@ fn hash128(input: u128) -> Result<u128, Error> {
 /// shares <x>, <y>, and <z> such that the AND of the XORs of the input values x and y equals
 /// the XOR of the output values z.
 async fn flaand(
-    (channel, delta): (&mut impl Channel, Delta),
+    (channel, delta): (&impl Channel, Delta),
     (xshares, yshares, rshares): (&[Share], &[Share], &[Share]),
     i: usize,
     n: usize,
@@ -779,7 +779,7 @@ type Bucket<'a> = Vec<(&'a Share, &'a Share, &'a Share)>;
 ///
 /// The protocol combines leaky authenticated bits into non-leaky authenticated bits.
 async fn faand(
-    (channel, delta): (&mut impl Channel, Delta),
+    (channel, delta): (&impl Channel, Delta),
     i: usize,
     n: usize,
     l: usize, //num_and_gates
@@ -829,7 +829,7 @@ async fn faand(
 
 /// Protocol that transforms precomputed AND triples to specific triples using Beaver's method.
 pub(crate) async fn beaver_aand(
-    (channel, delta): (&mut impl Channel, Delta),
+    (channel, delta): (&impl Channel, Delta),
     alpha_beta_shares: Vec<(Share, Share)>,
     i: usize,
     n: usize,
@@ -911,7 +911,7 @@ pub(crate) async fn beaver_aand(
 
 /// Check and return d-values for a vector of shares.
 async fn check_dvalue(
-    (channel, delta): (&mut impl Channel, Delta),
+    (channel, delta): (&impl Channel, Delta),
     i: usize,
     n: usize,
     buckets: &[Bucket<'_>],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! // Set up a simple channel for communication
-//! let mut channel = /* ... */
+//! let channel= /* ... */
 //!
 //! // Load or define a circuit
 //! let circuit = /* ... */
@@ -53,7 +53,7 @@
 //!
 //! // Execute the MPC protocol
 //! let result = mpc(
-//!     &mut channel,
+//!     &channel,
 //!     &circuit,
 //!     &my_inputs,
 //!     p_eval,

--- a/src/ot.rs
+++ b/src/ot.rs
@@ -16,7 +16,7 @@ pub(crate) fn block_to_u128(inp: Block) -> u128 {
 }
 
 pub(crate) async fn kos_ot_sender(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     deltas: &[Block],
     p_to: usize,
     shared_rand: &mut ChaCha20Rng,
@@ -35,7 +35,7 @@ pub(crate) async fn kos_ot_sender(
 }
 
 pub(crate) async fn kos_ot_receiver(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     bs: &[bool],
     p_to: usize,
     shared_rand: &mut ChaCha20Rng,

--- a/src/ot_core/alsz.rs
+++ b/src/ot_core/alsz.rs
@@ -43,7 +43,7 @@ pub(crate) struct Receiver<OT: OtSender<Msg = Block> + SemiHonest> {
 
 impl<OT: OtReceiver<Msg = Block> + SemiHonest> FixedKeyInitializer for Sender<OT> {
     async fn init_fixed_key<C: Channel, RNG: CryptoRng + Rng>(
-        channel: &mut C,
+        channel: &C,
         s_: [u8; 16],
         rng: &mut RNG,
         p_to: usize,
@@ -69,7 +69,7 @@ impl<OT: OtReceiver<Msg = Block> + SemiHonest> FixedKeyInitializer for Sender<OT
 impl<OT: OtReceiver<Msg = Block> + SemiHonest> Sender<OT> {
     pub(super) async fn send_setup<C: Channel>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         m: usize,
         p_to: usize,
     ) -> Result<Vec<u8>, Error> {
@@ -93,7 +93,7 @@ impl<OT: OtReceiver<Msg = Block> + SemiHonest> OtSender for Sender<OT> {
     type Msg = Block;
 
     async fn init<C: Channel, RNG: CryptoRng + Rng>(
-        channel: &mut C,
+        channel: &C,
         rng: &mut RNG,
         p_to: usize,
         shared_rand: &mut ChaCha20Rng,
@@ -105,7 +105,7 @@ impl<OT: OtReceiver<Msg = Block> + SemiHonest> OtSender for Sender<OT> {
 
     async fn send<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         inputs: &[(Self::Msg, Self::Msg)],
         _: &mut RNG,
         p_to: usize,
@@ -132,7 +132,7 @@ impl<OT: OtReceiver<Msg = Block> + SemiHonest> OtSender for Sender<OT> {
 impl<OT: OtReceiver<Msg = Block> + SemiHonest> CorrelatedSender for Sender<OT> {
     async fn send_correlated<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         deltas: &[Self::Msg],
         _: &mut RNG,
         p_to: usize,
@@ -161,7 +161,7 @@ impl<OT: OtReceiver<Msg = Block> + SemiHonest> CorrelatedSender for Sender<OT> {
 impl<OT: OtSender<Msg = Block> + SemiHonest> Receiver<OT> {
     pub(super) async fn recv_setup<C: Channel>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         r: &[u8],
         m: usize,
         p_to: usize,
@@ -190,7 +190,7 @@ impl<OT: OtSender<Msg = Block> + SemiHonest> OtReceiver for Receiver<OT> {
     type Msg = Block;
 
     async fn init<C: Channel, RNG: CryptoRng + Rng>(
-        channel: &mut C,
+        channel: &C,
         rng: &mut RNG,
         p_to: usize,
         shared_rand: &mut ChaCha20Rng,
@@ -218,7 +218,7 @@ impl<OT: OtSender<Msg = Block> + SemiHonest> OtReceiver for Receiver<OT> {
 
     async fn recv<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         inputs: &[bool],
         _: &mut RNG,
         p_to: usize,
@@ -244,7 +244,7 @@ impl<OT: OtSender<Msg = Block> + SemiHonest> OtReceiver for Receiver<OT> {
 impl<OT: OtSender<Msg = Block> + SemiHonest> CorrelatedReceiver for Receiver<OT> {
     async fn recv_correlated<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         inputs: &[bool],
         _: &mut RNG,
         p_to: usize,

--- a/src/ot_core/chou_orlandi.rs
+++ b/src/ot_core/chou_orlandi.rs
@@ -43,7 +43,7 @@ impl OtSender for Sender {
     type Msg = Block;
 
     async fn init<C: Channel, RNG: CryptoRng + Rng>(
-        channel: &mut C,
+        channel: &C,
         rng: &mut RNG,
         p_to: usize,
         _: &mut ChaCha20Rng,
@@ -56,7 +56,7 @@ impl OtSender for Sender {
 
     async fn send<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         inputs: &[(Block, Block)],
         _: &mut RNG,
         p_to: usize,
@@ -95,7 +95,7 @@ impl OtReceiver for Receiver {
     type Msg = Block;
 
     async fn init<C: Channel, RNG: CryptoRng + Rng>(
-        channel: &mut C,
+        channel: &C,
         _: &mut RNG,
         p_to: usize,
         _: &mut ChaCha20Rng,
@@ -108,7 +108,7 @@ impl OtReceiver for Receiver {
 
     async fn recv<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         inputs: &[bool],
         mut rng: &mut RNG,
         p_to: usize,

--- a/src/ot_core/kos.rs
+++ b/src/ot_core/kos.rs
@@ -38,7 +38,7 @@ pub(crate) struct Receiver<OT: OtSender<Msg = Block> + Malicious> {
 impl<OT: OtReceiver<Msg = Block> + Malicious> Sender<OT> {
     pub(super) async fn send_setup<C: Channel>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         m: usize,
         p_to: usize,
         shared_rand: &mut ChaCha20Rng,
@@ -72,7 +72,7 @@ impl<OT: OtReceiver<Msg = Block> + Malicious> Sender<OT> {
 
 impl<OT: OtReceiver<Msg = Block> + Malicious> FixedKeyInitializer for Sender<OT> {
     async fn init_fixed_key<C: Channel, RNG: CryptoRng + Rng>(
-        channel: &mut C,
+        channel: &C,
         s_: [u8; 16],
         rng: &mut RNG,
         p_to: usize,
@@ -87,7 +87,7 @@ impl<OT: OtReceiver<Msg = Block> + Malicious> OtSender for Sender<OT> {
     type Msg = Block;
 
     async fn init<C: Channel, RNG: CryptoRng + Rng>(
-        channel: &mut C,
+        channel: &C,
         rng: &mut RNG,
         p_to: usize,
         shared_rand: &mut ChaCha20Rng,
@@ -98,7 +98,7 @@ impl<OT: OtReceiver<Msg = Block> + Malicious> OtSender for Sender<OT> {
 
     async fn send<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         inputs: &[(Block, Block)],
         _: &mut RNG,
         p_to: usize,
@@ -126,7 +126,7 @@ impl<OT: OtReceiver<Msg = Block> + Malicious> OtSender for Sender<OT> {
 impl<OT: OtReceiver<Msg = Block> + Malicious> CorrelatedSender for Sender<OT> {
     async fn send_correlated<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         deltas: &[Self::Msg],
         _: &mut RNG,
         p_to: usize,
@@ -155,7 +155,7 @@ impl<OT: OtReceiver<Msg = Block> + Malicious> CorrelatedSender for Sender<OT> {
 impl<OT: OtSender<Msg = Block> + Malicious> Receiver<OT> {
     pub(super) async fn recv_setup<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         inputs: &[bool],
         _: &mut RNG,
         p_to: usize,
@@ -190,7 +190,7 @@ impl<OT: OtSender<Msg = Block> + Malicious> OtReceiver for Receiver<OT> {
     type Msg = Block;
 
     async fn init<C: Channel, RNG: CryptoRng + Rng>(
-        channel: &mut C,
+        channel: &C,
         rng: &mut RNG,
         p_to: usize,
         shared_rand: &mut ChaCha20Rng,
@@ -201,7 +201,7 @@ impl<OT: OtSender<Msg = Block> + Malicious> OtReceiver for Receiver<OT> {
 
     async fn recv<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         inputs: &[bool],
         rng: &mut RNG,
         p_to: usize,
@@ -232,7 +232,7 @@ impl<OT: OtSender<Msg = Block> + Malicious> OtReceiver for Receiver<OT> {
 impl<OT: OtSender<Msg = Block> + Malicious> CorrelatedReceiver for Receiver<OT> {
     async fn recv_correlated<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         inputs: &[bool],
         rng: &mut RNG,
         p_to: usize,

--- a/src/ot_core/mod.rs
+++ b/src/ot_core/mod.rs
@@ -47,7 +47,7 @@ where
     /// Runs any one-time initialization to create the oblivious transfer
     /// object.
     async fn init<C: Channel, RNG: CryptoRng + Rng>(
-        channel: &mut C,
+        channel: &C,
         rng: &mut RNG,
         p_to: usize,
         shared_rand: &mut ChaCha20Rng,
@@ -55,7 +55,7 @@ where
     /// Sends messages.
     async fn send<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         inputs: &[(Self::Msg, Self::Msg)],
         rng: &mut RNG,
         p_to: usize,
@@ -71,7 +71,7 @@ where
     /// Runs any one-time initialization to create the oblivious transfer
     /// object with a fixed key.
     async fn init_fixed_key<C: Channel, RNG: CryptoRng + Rng>(
-        channel: &mut C,
+        channel: &C,
         s_: [u8; 16],
         rng: &mut RNG,
         p_to: usize,
@@ -91,7 +91,7 @@ where
     /// Runs any one-time initialization to create the oblivious transfer
     /// object.
     async fn init<C: Channel, RNG: CryptoRng + Rng>(
-        channel: &mut C,
+        channel: &C,
         rng: &mut RNG,
         p_to: usize,
         shared_rand: &mut ChaCha20Rng,
@@ -99,7 +99,7 @@ where
     /// Receives messages.
     async fn recv<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         inputs: &[bool],
         rng: &mut RNG,
         p_to: usize,
@@ -118,7 +118,7 @@ where
     /// which specifies the offset between the zero and one message.
     async fn send_correlated<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         deltas: &[Self::Msg],
         rng: &mut RNG,
         p_to: usize,
@@ -135,7 +135,7 @@ where
     /// Correlated oblivious transfer receive.
     async fn recv_correlated<C: Channel, RNG: CryptoRng + Rng>(
         &mut self,
-        channel: &mut C,
+        channel: &C,
         inputs: &[bool],
         rng: &mut RNG,
         p_to: usize,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -213,7 +213,7 @@ pub(crate) enum Preprocessor {
 /// 4. Circuit evaluation: performed by the evaluator party only
 /// 5. Output determination: reveals the computation result to designated output parties
 pub async fn mpc(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     circuit: &Circuit,
     inputs: &[bool],
     p_eval: usize,
@@ -225,7 +225,7 @@ pub async fn mpc(
 }
 
 pub(crate) async fn _mpc(
-    channel: &mut impl Channel,
+    channel: &impl Channel,
     circuit: &Circuit,
     inputs: &[bool],
     p_fpre: Preprocessor,


### PR DESCRIPTION
This is a first step for #61. 

- The first commit is a search and replace that removes all the mutability modifiers that are not necessary anymore now that the Channel trait is changed to take `&self` (see #111). 
- The second commit then changes the `protocol.rs` implementation to do concurrent sending/receiving where it makes sense. This code could probably be made more DRY if we introduced a method like `recv_vec_from_all` but I want to first introduce concurrency in the other files as well before I come up with an abstraction.

I would recommend reviewing the commits separately since the first one is much larger but less interesting. I will introduce concurrency for other parts of the protocol in follow-up PRs. 