### PR TITLE
Improved bucketing in preprocessing protocol

### DIFF
--- a/src/block/gf128.rs
+++ b/src/block/gf128.rs
@@ -1,8 +1,5 @@
 use super::Block;
 
-/// The irreducible polynomial for gf128 operations.
-const MOD: u64 = 0b10000111; // 0x87
-
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 cpufeatures::new!(target_feature_pclmulqdq, "pclmulqdq");
 
@@ -116,7 +113,8 @@ mod clmul {
     #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64::*;
 
-    use super::MOD;
+    /// The irreducible polynomial for gf128 operations.
+    const MOD: u64 = 0b10000111; // 0x87
 
     /// Multiplication over GF(2^128) using pclmulqdq.
     ///

--- a/src/faand.rs
+++ b/src/faand.rs
@@ -1,7 +1,7 @@
 //! Preprocessing protocol generating authenticated triples for secure multi-party computation.
 use std::vec;
 
-use rand::{Rng, SeedableRng, random};
+use rand::{Rng, SeedableRng, random, seq::SliceRandom};
 use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 

--- a/src/faand.rs
+++ b/src/faand.rs
@@ -808,10 +808,7 @@ async fn faand(
     }
 
     // Pre-allocate buckets with known capacity
-    let mut buckets: Vec<Bucket> = Vec::with_capacity(l);
-    for _ in 0..l {
-        buckets.push(Vec::with_capacity(b));
-    }
+    let mut buckets: Vec<Bucket> = vec![Vec::with_capacity(b); l];
 
     // Distribute shuffled indices into buckets
     for (pos, &idx) in indices.iter().enumerate() {

--- a/src/faand.rs
+++ b/src/faand.rs
@@ -806,14 +806,14 @@ async fn faand(
         let j = shared_rand.random_range(0..=i);
         indices.swap(i, j);
     }
-    
+
     // Pre-allocate buckets with known capacity
     let mut buckets: Vec<Bucket> = Vec::with_capacity(l);
     for _ in 0..l {
         buckets.push(Vec::with_capacity(b));
     }
-    
-    // Distribute shuffled indices into buckets    
+
+    // Distribute shuffled indices into buckets
     for (pos, &idx) in indices.iter().enumerate() {
         let bucket_idx = pos % l;
         if buckets[bucket_idx].len() < b {


### PR DESCRIPTION
For better memory management and performance, we needed to look into improving the bucketing in [faand.rs](https://github.com/sine-fdn/polytune/blob/afa9760020fd0a605135c3e85a18e7301adb020a/src/faand.rs#L805). Addressing #124.

I consulted Claude for suggestions on which protocol to use and it provided the following three options:

> Recommendations:
> 
> Use Option 1 (Pre-shuffle) if you want the simplest and fastest approach. It's O(n log n) due to the shuffle, then O(n) for distribution.
> Use Option 2 (Available tracking) if you need more control over the distribution and want to ensure buckets are filled as evenly as possible.
> Option 3 (Fisher-Yates) gives you the most uniform random distribution.

I then checked the complexities, again with Claude, and decided to go with the Fisher-Yates method:

> Option 1 (Pre-shuffle):
> 
> Time: O(n log n) for shuffle + O(n) for assignment = O(n log n)
> Space: O(n) for indices vector
> Cache-friendly: Sequential access patterns
> No branching in the hot loop
> 
> Option 2 (Available tracking):
> 
> Time: O(n × l) in worst case when buckets fill up
> Space: O(l) for available vector
> More branching and random memory access
> 
> Option 3 (Fisher-Yates):
> 
> Time: O(n) for shuffle + O(n) for assignment = O(n)
> Space: O(n) for indices vector
> Best theoretical complexity

@robinhundt Could you generate another profile for join with 100 entries to see how the improvement looks like? 