### PR TITLE
CI: Hopefully finally fix the bench cache...

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,7 +29,10 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
       - run: cargo --version
       - name: CPU information
-        run: lscpu
+        id: cpu-info
+        run: |
+          lscpu
+          echo "cpu_model=$(lscpu | grep 'Model name' | sed 's/Model name: *//g' | tr -d ' ')" >> $GITHUB_OUTPUT
       - name: Cache compilation
         uses: ubicloud/rust-cache@65b3ff06b9bcc69d88c25e212f1ae3d14a0953c3
       - name: Restore criterion cache
@@ -37,13 +40,14 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.CRITERION_HOME }}
-          key: ${{ runner.os }}-${{ runner.arch }}-criterion-data
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ steps.cpu-info.outputs.cpu_model }}-criterion-data-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-${{ steps.cpu-info.outputs.cpu_model }}-criterion-data-
       - name: Run benchmarks
         run: |
           cargo bench --features "__bench" -- "${{ github.event.inputs.filter }}"
       - name: Save criterion cache
-          # always overwrite the cache on main branch runs so we can see the change to the previous
-        if: ${{ always() && !github.event.inputs.ref }}
+        if: ${{ !github.event.inputs.ref }}
         uses: actions/cache/save@v4
         with:
           path: ${{ env.CRITERION_HOME }}


### PR DESCRIPTION
I previously misunderstood how caches, the always() condition and restore keys work. This version should hopefully finally work.

Initially, I assumed that you can overwrite a cache if you save it with the same key, but this does not work. By including the commit sha in the cache key and specifying a restore key which is a prefix, the latest cache will be downloaded if there is no direct hit. I've also included the CPU model name in the cache key.

closes #132 