### PR TITLE
Prepare for 0.2.0-alpha.1 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,21 @@ jobs:
       - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
         with:
           toolchain: stable
+      - name: Install taplo for extracting polytune version
+        uses: taiki-e/install-action@f3a27926ea13d7be3ee2f4cbb925883cf9442b56
+        with:
+          tool: taplo@0.10.0
+      - name: Check that crate version matches tag version
+        run: |
+          polytune_version=$(taplo get -f Cargo.toml 'package.version')
+          tag_version=$(echo "${{ github.ref_name }}" | sed 's/v//')
+          if [[ "$polytune_version" != "$tag_version" ]]; then
+            echo "::error:: Polytune version ${polytune_version} does not match tag version ${tag_version}"
+            exit 1
+          fi
       - run: cargo test --release
       - run: cargo clippy -- -Dwarnings
       - run: cargo publish --token ${CRATES_TOKEN}
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
-      - run: cargo owner --add github:sine-fdn:staff --token ${CRATES_TOKEN}
-        env:
-          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "polytune"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "aes",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ workspace = { members = [
 ] }
 [package]
 name = "polytune"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Maliciously-Secure Multi-Party Computation (MPC) Engine using Authenticated Garbling"

--- a/examples/api-integration/Cargo.toml
+++ b/examples/api-integration/Cargo.toml
@@ -2,13 +2,14 @@
 name = "polytune-api-integration"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 anyhow = "1.0.79"
 axum = "0.7.4"
 blake3 = "1.5.1"
 clap = { version = "4.4.18", features = ["derive"] }
-polytune = { path = "../../", version = "0.1.0" }
+polytune = { path = "../../", version = "0.2.0-alpha.1" }
 reqwest = { version = "0.12.20", features = ["blocking", "json"] }
 serde = "1.0.197"
 tokio = { version = "1.46.1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/examples/http-multi-server-channels/Cargo.toml
+++ b/examples/http-multi-server-channels/Cargo.toml
@@ -2,12 +2,13 @@
 name = "polytune-http-multi-server"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 anyhow = "1.0.79"
 axum = "0.7.4"
 clap = { version = "4.4.18", features = ["derive"] }
-polytune = { path = "../../", version = "0.1.0" }
+polytune = { path = "../../", version = "0.2.0-alpha.1" }
 reqwest = "0.12.20"
 tokio = { version = "1.46.1", features = ["macros", "rt", "rt-multi-thread"] }
 tower-http = { version = "0.6.6", features = ["fs", "trace"] }

--- a/examples/http-single-server-channels/Cargo.toml
+++ b/examples/http-single-server-channels/Cargo.toml
@@ -2,11 +2,12 @@
 name = "polytune-http-single-server"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 axum = "0.7.4"
 clap = { version = "4.4.18", features = ["derive"] }
-polytune = { path = "../../", version = "0.1.0" }
+polytune = { path = "../../", version = "0.2.0-alpha.1" }
 reqwest = { version = "0.12.20", features = ["json"] }
 tokio = { version = "1.46.1", features = ["macros", "rt", "rt-multi-thread"] }
 tower-http = { version = "0.6.6", features = ["fs", "trace"] }

--- a/examples/sql-integration/Cargo.toml
+++ b/examples/sql-integration/Cargo.toml
@@ -2,13 +2,14 @@
 name = "polytune-sql-integration"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 anyhow = "1.0.79"
 axum = "0.7.4"
 blake3 = "1.5.1"
 clap = { version = "4.4.18", features = ["derive"] }
-polytune = { path = "../../", version = "0.1.0" }
+polytune = { path = "../../", version = "0.2.0-alpha.1" }
 reqwest = { version = "0.12.20", features = ["json"] }
 serde = "1.0.197"
 serde_json = "1.0.115"

--- a/examples/wasm-http-channels/Cargo.toml
+++ b/examples/wasm-http-channels/Cargo.toml
@@ -2,6 +2,7 @@
 name = "polytune-wasm-http-channels"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [[bin]]
 name = "broker"
@@ -52,7 +53,7 @@ tracing-subscriber = { version = "0.3.18", optional = true }
 #
 # for the client:
 #
-polytune = { path = "../../", version = "0.1.0" }
+polytune = { path = "../../", version = "0.2.0-alpha.1" }
 reqwest = "0.12.20"
 url = "2.5.4"
 wasm-bindgen = "0.2.100"


### PR DESCRIPTION
Oops, earlier I wanted to release the 0.1.0-alpha.1 version of polytune but accidentally released 0.1.0. While I pushed the `v0.1.0-alpha.1` tag, I completely forgot that this is not actually the version that is published on crates.io. That published version is specified in the `Cargo.toml` `package.version` field. 

As we intend to release this as a preliminary alpha version (which has less semver guarantees), I yanked the 0.1.0 version.

This PR properly prepares Polytune for a 0.2.0-alpha.1 release (we won't be able to release 0.1.0 later again) and also adds a check to the `publish` workflow which checks for a mismatch between the tag version and that in the Cargo.toml.

But at least we have the polytune name now on crates.io :sweat_smile: 