### PR TITLE
Remove message chunking

### DIFF
--- a/docs/src/examples/channel.md
+++ b/docs/src/examples/channel.md
@@ -3,7 +3,7 @@
 The `Channel` trait in our MPC engine provides a flexible and extensible abstraction for message-passing between parties. It allows communication to be implemented in various ways, enabling users to choose between platform-specific implementations. Polytune is deliberately communication-agnostic, while remaining quite flexible, offering the following features:
 
 - **Customizable Transport**: Implement the `Channel` trait using any transport mechanism — HTTP, WebSockets, in-memory queues, or custom networking protocols.
-- **Serialization-Aware**: The trait ensures that messages can be efficiently serialized and chunked when necessary, making it ideal for large payloads.
+- **Serialization-Aware**: The trait ensures that messages can be efficiently serialized.
 
 We provide example implementations for:
 
@@ -37,13 +37,13 @@ trait Channel {
         &self,
         p: usize,
         msg: Vec<u8>,
-        info: SendInfo,
+        phase: &str,
     ) -> Result<(), Self::SendError>;
 
     async fn recv_bytes_from(
         &self,
         p: usize,
-        info: RecvInfo,
+        phase: &str,
     ) -> Result<Vec<u8>, Self::RecvError>;
 }
 ```
@@ -53,7 +53,7 @@ trait Channel {
 1. **Channel Parameters**:
 
    - `p`: Index of the target party for send/receive
-   - `info`: Various information useful for logging
+   - `phase`: Phase of the protocol where the message is sent
    - `msg`: Message sent to the target party (only in `send_bytes_to`)
 
 2. **Connection Management**:

--- a/examples/api-integration/src/main.rs
+++ b/examples/api-integration/src/main.rs
@@ -379,19 +379,13 @@ impl Channel for HttpChannel {
         let client = reqwest::Client::new();
         let url = format!("{}msg/{}", self.urls[p], self.party);
         let mb = msg.len() as f64 / 1024.0 / 1024.0;
-        let i = info.sent();
-        let total = info.total();
         let phase = info.phase();
-        if i == 1 {
-            info!("Sending msg {phase} to party {p} ({mb:.2}MB), {i}/{total}...");
-        } else {
-            info!("  (sending msg {phase} to party {p} ({mb:.2}MB), {i}/{total})");
-        }
+        info!("Sending msg {phase} to party {p} ({mb:.2}MB)...");
         loop {
             sleep(Duration::from_millis(simulated_delay_in_ms)).await;
             let req = client.post(&url).body(msg.clone()).send();
             let Ok(Ok(res)) = timeout(Duration::from_secs(1), req).await else {
-                warn!("  req timeout: chunk {}/{} for party {}", i + 1, total, p);
+                warn!("  req timeout: party {}", p);
                 continue;
             };
             match res.status() {

--- a/examples/api-integration/src/main.rs
+++ b/examples/api-integration/src/main.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use clap::Parser;
 use polytune::{
-    channel::{Channel, RecvInfo, SendInfo},
+    channel::Channel,
     garble_lang::{compile_with_constants, literal::Literal},
     mpc,
 };
@@ -373,13 +373,12 @@ impl Channel for HttpChannel {
         &self,
         p: usize,
         msg: Vec<u8>,
-        info: SendInfo,
+        phase: &str,
     ) -> Result<(), Self::SendError> {
         let simulated_delay_in_ms = 300;
         let client = reqwest::Client::new();
         let url = format!("{}msg/{}", self.urls[p], self.party);
         let mb = msg.len() as f64 / 1024.0 / 1024.0;
-        let phase = info.phase();
         info!("Sending msg {phase} to party {p} ({mb:.2}MB)...");
         loop {
             sleep(Duration::from_millis(simulated_delay_in_ms)).await;
@@ -402,7 +401,7 @@ impl Channel for HttpChannel {
         }
     }
 
-    async fn recv_bytes_from(&self, p: usize, _info: RecvInfo) -> Result<Vec<u8>, Self::RecvError> {
+    async fn recv_bytes_from(&self, p: usize, _phase: &str) -> Result<Vec<u8>, Self::RecvError> {
         let mut r = self.recv[p].lock().await;
         timeout(Duration::from_secs(30 * 60), r.recv())
             .await

--- a/examples/http-multi-server-channels/src/main.rs
+++ b/examples/http-multi-server-channels/src/main.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use clap::Parser;
 use polytune::{
-    channel::{Channel, RecvInfo, SendInfo},
+    channel::Channel,
     garble_lang::compile,
     mpc,
 };
@@ -112,7 +112,7 @@ impl Channel for HttpChannel {
         &self,
         p: usize,
         msg: Vec<u8>,
-        _info: SendInfo,
+        _phase: &str,
     ) -> Result<(), Self::SendError> {
         let client = reqwest::Client::new();
         let url = format!("{}msg/{}", self.urls[p], self.party);
@@ -133,7 +133,7 @@ impl Channel for HttpChannel {
         }
     }
 
-    async fn recv_bytes_from(&self, p: usize, _info: RecvInfo) -> Result<Vec<u8>, Self::RecvError> {
+    async fn recv_bytes_from(&self, p: usize, _phase: &str) -> Result<Vec<u8>, Self::RecvError> {
         let mut r = self.recv[p].lock().await;
         Ok(timeout(Duration::from_secs(1), r.recv())
             .await

--- a/examples/http-multi-server-channels/src/main.rs
+++ b/examples/http-multi-server-channels/src/main.rs
@@ -6,11 +6,7 @@ use axum::{
     routing::post,
 };
 use clap::Parser;
-use polytune::{
-    channel::Channel,
-    garble_lang::compile,
-    mpc,
-};
+use polytune::{channel::Channel, garble_lang::compile, mpc};
 use reqwest::StatusCode;
 use std::{net::SocketAddr, path::PathBuf, result::Result, time::Duration};
 use tokio::{

--- a/examples/http-single-server-channels/src/http_channel.rs
+++ b/examples/http-single-server-channels/src/http_channel.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use polytune::channel::{Channel, RecvInfo, SendInfo};
+use polytune::channel::Channel;
 use reqwest::StatusCode;
 use tokio::time::sleep;
 
@@ -62,7 +62,7 @@ impl Channel for PollingHttpChannel {
         &self,
         p: usize,
         msg: Vec<u8>,
-        _info: SendInfo,
+        _phase: &str,
     ) -> Result<(), HttpChannelError> {
         let url = format!("{}/send/{}/{}/{}", self.url, self.session, self.party, p);
         let resp: reqwest::Response = self.client.post(url).body(msg).send().await?;
@@ -76,7 +76,7 @@ impl Channel for PollingHttpChannel {
     async fn recv_bytes_from(
         &self,
         p: usize,
-        _info: RecvInfo,
+        _phase: &str,
     ) -> Result<Vec<u8>, HttpChannelError> {
         let url = format!("{}/recv/{}/{}/{}", self.url, self.session, p, self.party);
         let mut attempts = 0;

--- a/examples/http-single-server-channels/src/http_channel.rs
+++ b/examples/http-single-server-channels/src/http_channel.rs
@@ -73,11 +73,7 @@ impl Channel for PollingHttpChannel {
         }
     }
 
-    async fn recv_bytes_from(
-        &self,
-        p: usize,
-        _phase: &str,
-    ) -> Result<Vec<u8>, HttpChannelError> {
+    async fn recv_bytes_from(&self, p: usize, _phase: &str) -> Result<Vec<u8>, HttpChannelError> {
         let url = format!("{}/recv/{}/{}/{}", self.url, self.session, p, self.party);
         let mut attempts = 0;
         loop {

--- a/examples/sql-integration/src/main.rs
+++ b/examples/sql-integration/src/main.rs
@@ -695,19 +695,13 @@ impl Channel for HttpChannel {
         let client = reqwest::Client::new();
         let url = format!("{}msg/{}", self.urls[p], self.party);
         let mb = msg.len() as f64 / 1024.0 / 1024.0;
-        let i = info.sent();
-        let total = info.total();
         let phase = info.phase();
-        if i == 1 {
-            info!("Sending msg {phase} to party {p} ({mb:.2}MB), {i}/{total}...");
-        } else {
-            info!("  (sending msg {phase} to party {p} ({mb:.2}MB), {i}/{total})");
-        }
+        info!("Sending msg {phase} to party {p} ({mb:.2}MB)...");
         loop {
             sleep(Duration::from_millis(simulated_delay_in_ms)).await;
             let req = client.post(&url).body(msg.clone()).send();
             let Ok(Ok(res)) = timeout(Duration::from_secs(1), req).await else {
-                warn!("  req timeout: chunk {}/{} for party {}", i + 1, total, p);
+                warn!("  req timeout: party {}", p);
                 continue;
             };
             match res.status() {

--- a/examples/sql-integration/src/main.rs
+++ b/examples/sql-integration/src/main.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use clap::Parser;
 use polytune::{
-    channel::{Channel, RecvInfo, SendInfo},
+    channel::Channel,
     garble_lang::{
         ast::{Type, Variant},
         compile_with_constants,
@@ -689,13 +689,12 @@ impl Channel for HttpChannel {
         &self,
         p: usize,
         msg: Vec<u8>,
-        info: SendInfo,
+        phase: &str,
     ) -> Result<(), Self::SendError> {
         let simulated_delay_in_ms = 300;
         let client = reqwest::Client::new();
         let url = format!("{}msg/{}", self.urls[p], self.party);
         let mb = msg.len() as f64 / 1024.0 / 1024.0;
-        let phase = info.phase();
         info!("Sending msg {phase} to party {p} ({mb:.2}MB)...");
         loop {
             sleep(Duration::from_millis(simulated_delay_in_ms)).await;
@@ -718,7 +717,7 @@ impl Channel for HttpChannel {
         }
     }
 
-    async fn recv_bytes_from(&self, p: usize, _info: RecvInfo) -> Result<Vec<u8>, Self::RecvError> {
+    async fn recv_bytes_from(&self, p: usize, _phase: &str) -> Result<Vec<u8>, Self::RecvError> {
         let mut r = self.recv[p].lock().await;
         timeout(Duration::from_secs(30 * 60), r.recv())
             .await

--- a/examples/wasm-http-channels/src/lib.rs
+++ b/examples/wasm-http-channels/src/lib.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use gloo_timers::future::TimeoutFuture;
 use polytune::{
-    channel::{Channel, RecvInfo, SendInfo},
+    channel::Channel,
     garble_lang::{compile, literal::Literal, token::SignedNumType},
     mpc,
 };
@@ -64,7 +64,7 @@ impl Channel for HttpChannel {
         &self,
         p: usize,
         msg: Vec<u8>,
-        _info: SendInfo,
+        _phase: &str,
     ) -> Result<(), Self::SendError> {
         let client = reqwest::Client::new();
         let url = format!("{}send/{}/{}", self.url, self.party, p);
@@ -83,7 +83,7 @@ impl Channel for HttpChannel {
         return Err(format!("Could not reach {url}"));
     }
 
-    async fn recv_bytes_from(&self, p: usize, _info: RecvInfo) -> Result<Vec<u8>, Self::RecvError> {
+    async fn recv_bytes_from(&self, p: usize, _phase: &str) -> Result<Vec<u8>, Self::RecvError> {
         let client = reqwest::Client::new();
         let url = format!("{}recv/{}/{}", self.url, self.party, p);
         for _ in 0..50 {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -82,11 +82,7 @@ pub trait Channel {
 
     /// Awaits a response from the party with the given index (must be between `0..participants`).
     #[allow(async_fn_in_trait)]
-    async fn recv_bytes_from(
-        &self,
-        party: usize,
-        phase: &str,
-    ) -> Result<Vec<u8>, Self::RecvError>;
+    async fn recv_bytes_from(&self, party: usize, phase: &str) -> Result<Vec<u8>, Self::RecvError>;
 }
 
 /// Serializes and sends an MPC message to the other party.


### PR DESCRIPTION
As described in #60, we were chunking messages by number of objects, not number of bytes. It is unclear yet if chunking is really necessary to this point, so we agreed on removing it for now. If it needs to be added in for a specific `Channel` implementation, we can do that.

This PR is structured such that the first commit only removed the chunking but did not change anything about `SendInfo` and `RecvInfo`. The second commit then removes `current_msg` and `remaining_msgs` from `SendInfo` and `RecvInfo`, but `phase` is still within that. The thirs then substitutes the use of `RecvInfo` and `SendInfo` with `phase` only.