### PR TITLE
Add peak memory tracking to sql-integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,6 +1827,7 @@ dependencies = [
  "getrandom 0.2.16",
  "getrandom 0.3.3",
  "hybrid-array",
+ "polytune-test-utils",
  "proptest",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
@@ -1899,6 +1900,7 @@ dependencies = [
  "blake3",
  "clap",
  "polytune",
+ "polytune-test-utils",
  "reqwest",
  "serde",
  "serde_json",
@@ -1909,6 +1911,13 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "polytune-test-utils"
+version = "0.1.0"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 workspace = { members = [
+    "crates/polytune-test-utils",
+    "examples/api-integration",
     "examples/http-multi-server-channels",
     "examples/http-single-server-channels",
     "examples/wasm-http-channels",
     "examples/sql-integration",
-    "examples/api-integration",
 ] }
 [package]
 name = "polytune"
@@ -77,6 +78,7 @@ cpufeatures = "0.2.17"
 
 [dev-dependencies]
 criterion = { version = "0.6.0", features = ["async_tokio"] }
+polytune-test-utils = { path = "crates/polytune-test-utils" }
 proptest = "1.7.0"
 tokio = { version = "1.46.1", features = ["full"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,7 +1,6 @@
 use criterion::Criterion;
+use polytune_test_utils::peak_alloc::PeakAllocator;
 use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
-
-use crate::memory_tracking::PeakAllocator;
 
 mod join;
 mod memory_tracking;

--- a/benches/memory_tracking.rs
+++ b/benches/memory_tracking.rs
@@ -1,123 +1,10 @@
-use std::{
-    alloc::{GlobalAlloc, System},
-    cell::Cell,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
-};
-
 use criterion::measurement::{Measurement, ValueFormatter};
-use tokio::runtime::Runtime;
+use polytune_test_utils::peak_alloc::{MAX_PARTIES, scale_memory};
 
 use crate::ALLOCATOR;
 
-/// Maximum number of parties the [`PeakAllocator`] can track.
-pub const MAX_PARTIES: usize = 16;
-
-thread_local! {
-    /// The current id of the party executing on this thread.
-    ///
-    /// This is set by [`create_instrumented_runtime`] and used by the [`PeakAllocator`].
-    static PARTY_IDX: Cell<usize> = const { Cell::new(MAX_PARTIES) };
-}
-
-/// A [`GlobalAlloc`] that tracks the peak memory allocation of multiple parties.
-///
-/// For this to work, the futures executed by the parties need to be executed on
-/// a Criterion [`Runtime`] created by [`create_instrumented_runtime`]. The instrumented
-/// Runtime can be used in combination with the criterion [`MemoryMeasurement`].
-pub struct PeakAllocator {
-    enabled: AtomicBool,
-    // we allocate + 1 slot for allocations not associated with a party (id == MAX_PARTIES)
-    current: [AtomicUsize; MAX_PARTIES + 1],
-    peak: [AtomicUsize; MAX_PARTIES + 1],
-}
-
-impl PeakAllocator {
-    /// Returns a new disabled [`PeakAllocator`].
-    pub const fn new() -> Self {
-        PeakAllocator {
-            enabled: AtomicBool::new(false),
-            current: [const { AtomicUsize::new(0) }; MAX_PARTIES + 1],
-            peak: [const { AtomicUsize::new(0) }; MAX_PARTIES + 1],
-        }
-    }
-
-    /// Enable the peak memory tracking.
-    pub fn enable(&self) {
-        self.enabled.store(true, Ordering::Relaxed);
-    }
-
-    /// Disable the peak memory tracking.
-    pub fn disable(&self) {
-        self.enabled.store(false, Ordering::Relaxed);
-    }
-
-    /// Whether the peak memory tracking is enabled.
-    pub fn is_enabled(&self) -> bool {
-        self.enabled.load(Ordering::Relaxed)
-    }
-
-    /// Resets the current and peak memory allocation trackers.
-    pub fn reset(&self) {
-        for val in &self.current {
-            val.store(0, Ordering::Relaxed);
-        }
-        for val in &self.peak {
-            val.store(0, Ordering::Relaxed);
-        }
-    }
-
-    /// Get the peak memory consumption for `party`.
-    pub fn peak(&self, party: usize) -> usize {
-        self.peak[party].load(Ordering::Relaxed)
-    }
-}
-
-/// Delegate allocations to the [`System`] allocator while tracking peak allocation for each party.
-unsafe impl GlobalAlloc for PeakAllocator {
-    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
-        // Safety: We forward the layout to the system allocator. The requirements are guaranteed by our caller.
-        let ret = unsafe { System.alloc(layout) };
-        if !ret.is_null() && self.is_enabled() {
-            let party_idx = PARTY_IDX.get();
-            let prev = self.current[party_idx].fetch_add(layout.size(), Ordering::Relaxed);
-            self.peak[party_idx].fetch_max(prev + layout.size(), Ordering::Relaxed);
-        }
-        ret
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
-        // Safety: We simply forward ptr and layout to the System allocator
-        unsafe {
-            System.dealloc(ptr, layout);
-        }
-        if self.is_enabled() {
-            let party_idx = PARTY_IDX.get();
-
-            self.current[party_idx]
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
-                    Some(val.saturating_sub(layout.size()))
-                })
-                .expect("unreachable because we don't return None");
-        }
-    }
-}
-
-/// Create a tokio [`Runtime`] set up for memory tracking with the [`PeakAllocator`].
-pub fn create_instrumented_runtime(party_idx: usize) -> Runtime {
-    assert!(
-        party_idx < MAX_PARTIES,
-        "party_idx must be less than MAX_PARTIES: {MAX_PARTIES}"
-    );
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .on_thread_start(move || {
-            PARTY_IDX.set(party_idx);
-        })
-        .build()
-        .expect("runtime create")
-}
-
-/// Criterion [`Measurement`] to use with [`PeakAllocator`] and [`create_instrumented_runtime`].
+/// Criterion [`Measurement`] to use with [`polytune_test_utils::peak_alloc::PeakAllocator`]
+/// and [`polytune_test_utils::peak_alloc::create_instrumented_runtime`].
 #[derive(Copy, Clone, Debug)]
 pub struct MemoryMeasurement {
     party: usize,
@@ -168,15 +55,7 @@ pub struct MemoryFormatter;
 // Implementation based on `DurationFormatter` in criterion.
 impl ValueFormatter for MemoryFormatter {
     fn scale_values(&self, typical_value: f64, values: &mut [f64]) -> &'static str {
-        let (denom, unit) = if typical_value < 1_000.0 {
-            (1.0, " B")
-        } else if typical_value < 1_000.0_f64.powi(2) {
-            (1_000.0, " KB")
-        } else if typical_value < 1_000.0_f64.powi(3) {
-            (1_000.0_f64.powi(2), " MB")
-        } else {
-            (1_000.0_f64.powi(3), " GB")
-        };
+        let (denom, unit) = scale_memory(typical_value);
 
         for val in values.iter_mut() {
             *val /= denom;

--- a/benches/mpc.rs
+++ b/benches/mpc.rs
@@ -6,9 +6,10 @@ use criterion::{
 };
 use garble_lang::circuit::{Circuit, Gate};
 use polytune::{channel, mpc};
+use polytune_test_utils::peak_alloc::create_instrumented_runtime;
 use tokio::{runtime::Runtime, sync::oneshot};
 
-use crate::memory_tracking::{MemoryMeasurement, create_instrumented_runtime};
+use crate::memory_tracking::MemoryMeasurement;
 
 pub fn mpc_benchmarks(c: &mut Criterion) {
     let rt0 = create_instrumented_runtime(0);

--- a/crates/polytune-test-utils/Cargo.toml
+++ b/crates/polytune-test-utils/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "polytune-test-utils"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+tokio = {version = "1.46.1", features = ["rt-multi-thread"]}

--- a/crates/polytune-test-utils/src/lib.rs
+++ b/crates/polytune-test-utils/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod peak_alloc;

--- a/crates/polytune-test-utils/src/peak_alloc.rs
+++ b/crates/polytune-test-utils/src/peak_alloc.rs
@@ -1,0 +1,134 @@
+use std::{
+    alloc::{GlobalAlloc, System},
+    cell::Cell,
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+
+use tokio::runtime::Runtime;
+
+/// Maximum number of parties the [`PeakAllocator`] can track.
+pub const MAX_PARTIES: usize = 16;
+
+thread_local! {
+    /// The current id of the party executing on this thread.
+    ///
+    /// This is set by [`create_instrumented_runtime`] and used by the [`PeakAllocator`].
+    static PARTY_IDX: Cell<usize> = const { Cell::new(MAX_PARTIES) };
+}
+
+/// A [`GlobalAlloc`] that tracks the peak memory allocation of multiple parties.
+///
+/// For this to work, the futures executed by the parties need to be executed on
+/// a Criterion [`Runtime`] created by [`create_instrumented_runtime`]. The instrumented
+/// Runtime can be used in combination with the criterion [`MemoryMeasurement`].
+pub struct PeakAllocator {
+    enabled: AtomicBool,
+    // we allocate + 1 slot for allocations not associated with a party (id == MAX_PARTIES)
+    current: [AtomicUsize; MAX_PARTIES + 1],
+    peak: [AtomicUsize; MAX_PARTIES + 1],
+}
+
+impl PeakAllocator {
+    /// Returns a new disabled [`PeakAllocator`].
+    pub const fn new() -> Self {
+        PeakAllocator {
+            enabled: AtomicBool::new(false),
+            current: [const { AtomicUsize::new(0) }; MAX_PARTIES + 1],
+            peak: [const { AtomicUsize::new(0) }; MAX_PARTIES + 1],
+        }
+    }
+
+    /// Enable the peak memory tracking.
+    pub fn enable(&self) {
+        self.enabled.store(true, Ordering::Relaxed);
+    }
+
+    /// Disable the peak memory tracking.
+    pub fn disable(&self) {
+        self.enabled.store(false, Ordering::Relaxed);
+    }
+
+    /// Whether the peak memory tracking is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    /// Resets the current and peak memory allocation trackers.
+    pub fn reset(&self) {
+        for val in &self.current {
+            val.store(0, Ordering::Relaxed);
+        }
+        for val in &self.peak {
+            val.store(0, Ordering::Relaxed);
+        }
+    }
+
+    /// Get the peak memory consumption for `party`.
+    pub fn peak(&self, party: usize) -> usize {
+        self.peak[party].load(Ordering::Relaxed)
+    }
+}
+
+/// Delegate allocations to the [`System`] allocator while tracking peak allocation for each party.
+unsafe impl GlobalAlloc for PeakAllocator {
+    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+        // Safety: We forward the layout to the system allocator. The requirements are guaranteed by our caller.
+        let ret = unsafe { System.alloc(layout) };
+        if !ret.is_null() && self.is_enabled() {
+            let party_idx = PARTY_IDX.get();
+            let prev = self.current[party_idx].fetch_add(layout.size(), Ordering::Relaxed);
+            self.peak[party_idx].fetch_max(prev + layout.size(), Ordering::Relaxed);
+        }
+        ret
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
+        // Safety: We simply forward ptr and layout to the System allocator
+        unsafe {
+            System.dealloc(ptr, layout);
+        }
+        if self.is_enabled() {
+            let party_idx = PARTY_IDX.get();
+
+            self.current[party_idx]
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
+                    Some(val.saturating_sub(layout.size()))
+                })
+                .expect("unreachable because we don't return None");
+        }
+    }
+}
+
+impl Default for PeakAllocator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Create a tokio [`Runtime`] set up for memory tracking with the [`PeakAllocator`].
+pub fn create_instrumented_runtime(party_idx: usize) -> Runtime {
+    assert!(
+        party_idx < MAX_PARTIES,
+        "party_idx must be less than MAX_PARTIES: {MAX_PARTIES}"
+    );
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .on_thread_start(move || {
+            PARTY_IDX.set(party_idx);
+        })
+        .build()
+        .expect("runtime create")
+}
+
+/// Scale the memory in bytes depending on its size and return the scaled value plus unit.
+pub fn scale_memory(bytes: f64) -> (f64, &'static str) {
+    if bytes < 1_000.0 {
+        (1.0, " B")
+    } else if bytes < 1_000.0_f64.powi(2) {
+        (1_000.0, " KB")
+    } else if bytes < 1_000.0_f64.powi(3) {
+        (1_000.0_f64.powi(2), " MB")
+    } else {
+        (1_000.0_f64.powi(3), " GB")
+    }
+}

--- a/examples/sql-integration/Cargo.toml
+++ b/examples/sql-integration/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "polytune-sql-integration"
-version = "0.1.0"
 edition = "2024"
+name = "polytune-sql-integration"
 publish = false
+version = "0.1.0"
 
 [dependencies]
 anyhow = "1.0.79"
@@ -10,6 +10,7 @@ axum = "0.7.4"
 blake3 = "1.5.1"
 clap = { version = "4.5.41", features = ["derive"] }
 polytune = { path = "../../", version = "0.2.0-alpha.1" }
+polytune-test-utils = { path = "../../crates/polytune-test-utils" }
 reqwest = { version = "0.12.22", features = ["json"] }
 serde = "1.0.197"
 serde_json = "1.0.115"


### PR DESCRIPTION
The sql-integration example will now report its peak memory consumption. This is done via our `PeakAllocator` `GlobalAlloc` which is extracted into a separate crate and now used by the sql example and polytune as a dev dependency.