### PR TITLE
Api integration fix for platforms where tcp_user_timeout does not work

### DIFF
--- a/examples/api-integration/README.md
+++ b/examples/api-integration/README.md
@@ -9,7 +9,7 @@ The example uses two parties, which communicate over MPC without the need for a 
 The easiest way to run the example is as a test that orchestrates the two parties:
 
 ```
-cargo test --release -- --nocapture
+cargo t --profile debug-release
 ```
 
 ## How to Deploy the Engine

--- a/examples/api-integration/src/main.rs
+++ b/examples/api-integration/src/main.rs
@@ -300,9 +300,15 @@ async fn execute_mpc(state: MpcState, policy: &Policy) -> Result<Option<Literal>
             receivers.push(Mutex::new(r));
         }
 
-        let client = reqwest::ClientBuilder::new()
-            .tcp_user_timeout(Duration::from_secs(10 * 60))
-            .build()?;
+        #[allow(unused_mut)]
+        let mut builder = reqwest::ClientBuilder::new();
+
+        #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+        {
+            builder = builder.tcp_user_timeout(Duration::from_secs(10 * 60));
+        }
+
+        let client = builder.build()?;
 
         HttpChannel {
             client,


### PR DESCRIPTION
The api-integration example wasn't working on a mac anymore due to using `tcp_user_timeout`. Now this is made conditional similarly to its definition `#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]`.