### PR TITLE
Use join and join_iter from Garble after recent renaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ dependencies = [
 [[package]]
 name = "garble_lang"
 version = "0.7.0"
-source = "git+https://github.com/sine-fdn/garble-lang.git?branch=join-inbuilt-func#820fa1a76b5e1e2a9e8dfff94e67de3c1921992e"
+source = "git+https://github.com/sine-fdn/garble-lang.git#eb47fd58c8c0e68044dafc46c57110d09e94a962"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,4 +98,4 @@ debug = true
 inherits = "release"
 
 [patch.crates-io]
-garble_lang = { git = "https://github.com/sine-fdn/garble-lang.git", branch = "join-inbuilt-func" }
+garble_lang = { git = "https://github.com/sine-fdn/garble-lang.git" }

--- a/examples/api-integration/.example.garble.rs
+++ b/examples/api-integration/.example.garble.rs
@@ -6,5 +6,5 @@ pub fn main(
     measles_cases: [[u8; ID_LEN]; ROWS_0],
     school_examinations: [[u8; ID_LEN]; ROWS_1],
 ) -> [(bool, [u8; ID_LEN]); const { ROWS_0 + ROWS_1 - 1usize}] {
-    bitonic_join(measles_cases, school_examinations)
+    join(measles_cases, school_examinations)
 }

--- a/examples/api-integration/policy0-big.json
+++ b/examples/api-integration/policy0-big.json
@@ -3,7 +3,7 @@
     "http://localhost:8000/",
     "http://localhost:8001/"
   ],
-  "program": "const ROWS_0: usize = PARTY_0::ROWS;\nconst ROWS_1: usize = PARTY_1::ROWS;\nconst ID_LEN: usize = max(PARTY_0::ID_LEN, PARTY_1::ID_LEN);\n\npub fn main(\n    measles_cases: [[u8; ID_LEN]; ROWS_0],\n    school_examinations: [[u8; ID_LEN]; ROWS_1],\n) -> [(bool, [u8; ID_LEN]); const { ROWS_0 + ROWS_1 - 1usize}] {\n    bitonic_join(measles_cases, school_examinations)\n}\n",
+  "program": "const ROWS_0: usize = PARTY_0::ROWS;\nconst ROWS_1: usize = PARTY_1::ROWS;\nconst ID_LEN: usize = max(PARTY_0::ID_LEN, PARTY_1::ID_LEN);\n\npub fn main(\n    measles_cases: [[u8; ID_LEN]; ROWS_0],\n    school_examinations: [[u8; ID_LEN]; ROWS_1],\n) -> [(bool, [u8; ID_LEN]); const { ROWS_0 + ROWS_1 - 1usize}] {\n    join(measles_cases, school_examinations)\n}\n",
   "leader": 0,
   "party": 0,
   "input": {

--- a/examples/api-integration/policy0.json
+++ b/examples/api-integration/policy0.json
@@ -1,6 +1,6 @@
 {
   "participants": ["http://localhost:8000", "http://localhost:8001"],
-  "program": "const ROWS_0: usize = PARTY_0::ROWS;\nconst ROWS_1: usize = PARTY_1::ROWS;\nconst ID_LEN: usize = max(PARTY_0::ID_LEN, PARTY_1::ID_LEN);\n\npub fn main(\n    measles_cases: [[u8; ID_LEN]; ROWS_0],\n    school_examinations: [[u8; ID_LEN]; ROWS_1],\n) -> [(bool, [u8; ID_LEN]); const { ROWS_0 + ROWS_1 - 1usize}] {\n    bitonic_join(measles_cases, school_examinations)\n}\n",
+  "program": "const ROWS_0: usize = PARTY_0::ROWS;\nconst ROWS_1: usize = PARTY_1::ROWS;\nconst ID_LEN: usize = max(PARTY_0::ID_LEN, PARTY_1::ID_LEN);\n\npub fn main(\n    measles_cases: [[u8; ID_LEN]; ROWS_0],\n    school_examinations: [[u8; ID_LEN]; ROWS_1],\n) -> [(bool, [u8; ID_LEN]); const { ROWS_0 + ROWS_1 - 1usize}] {\n    join(measles_cases, school_examinations)\n}\n",
   "leader": 0,
   "party": 0,
   "input": {

--- a/examples/api-integration/policy1-big.json
+++ b/examples/api-integration/policy1-big.json
@@ -3,7 +3,7 @@
     "http://localhost:8000/",
     "http://localhost:8001/"
   ],
-  "program": "const ROWS_0: usize = PARTY_0::ROWS;\nconst ROWS_1: usize = PARTY_1::ROWS;\nconst ID_LEN: usize = max(PARTY_0::ID_LEN, PARTY_1::ID_LEN);\n\npub fn main(\n    measles_cases: [[u8; ID_LEN]; ROWS_0],\n    school_examinations: [[u8; ID_LEN]; ROWS_1],\n) -> [(bool, [u8; ID_LEN]); const { ROWS_0 + ROWS_1 - 1usize}] {\n    bitonic_join(measles_cases, school_examinations)\n}\n",
+  "program": "const ROWS_0: usize = PARTY_0::ROWS;\nconst ROWS_1: usize = PARTY_1::ROWS;\nconst ID_LEN: usize = max(PARTY_0::ID_LEN, PARTY_1::ID_LEN);\n\npub fn main(\n    measles_cases: [[u8; ID_LEN]; ROWS_0],\n    school_examinations: [[u8; ID_LEN]; ROWS_1],\n) -> [(bool, [u8; ID_LEN]); const { ROWS_0 + ROWS_1 - 1usize}] {\n    join(measles_cases, school_examinations)\n}\n",
   "leader": 0,
   "party": 1,
   "input": {

--- a/examples/api-integration/policy1.json
+++ b/examples/api-integration/policy1.json
@@ -1,6 +1,6 @@
 {
   "participants": ["http://localhost:8000", "http://localhost:8001"],
-  "program": "const ROWS_0: usize = PARTY_0::ROWS;\nconst ROWS_1: usize = PARTY_1::ROWS;\nconst ID_LEN: usize = max(PARTY_0::ID_LEN, PARTY_1::ID_LEN);\n\npub fn main(\n    measles_cases: [[u8; ID_LEN]; ROWS_0],\n    school_examinations: [[u8; ID_LEN]; ROWS_1],\n) -> [(bool, [u8; ID_LEN]); const { ROWS_0 + ROWS_1 - 1usize}] {\n    bitonic_join(measles_cases, school_examinations)\n}\n",
+  "program": "const ROWS_0: usize = PARTY_0::ROWS;\nconst ROWS_1: usize = PARTY_1::ROWS;\nconst ID_LEN: usize = max(PARTY_0::ID_LEN, PARTY_1::ID_LEN);\n\npub fn main(\n    measles_cases: [[u8; ID_LEN]; ROWS_0],\n    school_examinations: [[u8; ID_LEN]; ROWS_1],\n) -> [(bool, [u8; ID_LEN]); const { ROWS_0 + ROWS_1 - 1usize}] {\n    join(measles_cases, school_examinations)\n}\n",
   "leader": 0,
   "party": 1,
   "input": {

--- a/examples/sql-integration/.example.garble.rs
+++ b/examples/sql-integration/.example.garble.rs
@@ -7,7 +7,7 @@ pub fn main(
     disability: [([u8; ID_LEN], u8); ROWS_1],
 ) -> [u16; 10] {
     let mut result: [u16; 10] = [0u16; 10];
-    for joined in join(location, disability) {
+    for joined in join_iter(location, disability) {
         let ((_, loc), (_, care_level)) = joined;
         if care_level >= 4 {
             result[loc as usize] += 1u16;


### PR DESCRIPTION
Following the recent renaming of the `for` `join` loop to `for` `join_iter` and `bitonic_join` to `join` in [PR #213 in Garble](https://github.com/sine-fdn/garble-lang/pull/213), we have updated the `api-integration` and `sql-integration` examples in polytune to reflect this change.