### PR TITLE
Fix join benchmark

### DIFF
--- a/benches/.join.garble.rs
+++ b/benches/.join.garble.rs
@@ -13,7 +13,7 @@ pub fn main(
 ) -> [(u16, u16); 1] {
     let mut missing_screenings_with_special_ed_needs = 0u16;
     let mut total = ROWS_1 as u16;
-    for joined in join(screenings, school_examinations) {
+    for joined in join_iter(screenings, school_examinations) {
         let ((_, screening), (_, special_ed_needs)) = joined;
         if special_ed_needs <= 2u8 {
             match screening {

--- a/docs/src/examples/sql.md
+++ b/docs/src/examples/sql.md
@@ -1,6 +1,6 @@
 # SQL Integration
 
-This example is more advanced and shows how to load data from different input databases (PostgreSQL + MySQL), convert the rows to Garble language data types, join them together (using the built-in `join` function of the Garble language) and write the output to a third (PostgreSQL) database.
+This example is more advanced and shows how to load data from different input databases (PostgreSQL + MySQL), convert the rows to Garble language data types, join them together (using the built-in `join_iter` function of the Garble language) and write the output to a third (PostgreSQL) database.
 
 The example uses two parties, which communicate over MPC without the need for a trusted (or semi-trusted) third party. Each party runs an HTTP server to receive incoming messages and sends messages by sending HTTP requests to the other party. The MPC program as well as any configuration necessary to read from / write to databases is specified in a JSON policy file which is read on startup.
 


### PR DESCRIPTION
#184 broke the benches/join.rs benchmark as it still used the `join` function instead of `join_iter`.