### PR TITLE
Optionally store intermediate data in tmp files

### DIFF
--- a/.github/workflows/bench_large_join.yml
+++ b/.github/workflows/bench_large_join.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   bench_large_join:
-    runs-on: ubicloud-standard-30-ubuntu-2404
+    runs-on: ubicloud-standard-8-ubuntu-2404
     timeout-minutes: 30
     defaults:
       run:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 
 heaptrack*.zst
+.tmp*
 *.tmp
 # samply output
 *.json.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,6 +1837,7 @@ dependencies = [
  "seq-macro",
  "serde",
  "subtle",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",
@@ -2867,15 +2868,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,6 +1861,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tower",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ rand_core_0_6 = { package = "rand_core", version = "0.6" }
 seq-macro = "0.3.6"
 serde = { version = "1.0.195", features = ["derive"] }
 subtle = "2.6.1"
+tempfile = "3.21.0"
 thiserror = "2.0.16"
 tokio = { version = "1.47.1", features = ["macros", "rt", "sync", "time"] }
 tracing = "0.1.41"

--- a/benches/join.rs
+++ b/benches/join.rs
@@ -31,7 +31,17 @@ async fn simulate_mpc_async(
         let inputs = inputs.to_vec();
         let output_parties = output_parties.to_vec();
         computation.spawn(async move {
-            match mpc(&channel, &circuit, &inputs, p_eval, p_own, &output_parties).await {
+            match mpc(
+                &channel,
+                &circuit,
+                &inputs,
+                p_eval,
+                p_own,
+                &output_parties,
+                None,
+            )
+            .await
+            {
                 Ok(res) => {
                     info!(
                         "Party {p_own} sent {:.2}MB of messages",
@@ -53,6 +63,7 @@ async fn simulate_mpc_async(
         p_eval,
         p_eval,
         output_parties,
+        None,
     )
     .await;
     match eval_result {

--- a/benches/mpc.rs
+++ b/benches/mpc.rs
@@ -183,7 +183,7 @@ fn bench_circuit_two_parties<'a, M, F>(
                 // this means that we must recreate the SimpleChannel and circ above, because the future needs to
                 // be 'static for spawning.
                 let fut = async move {
-                    mpc(&ch1, &circ1, &inputs1, 0, 0, &p_out)
+                    mpc(&ch1, &circ1, &inputs1, 0, 0, &p_out, None)
                         .await
                         .expect("mpc execution failed")
                 };
@@ -195,7 +195,7 @@ fn bench_circuit_two_parties<'a, M, F>(
                     tx.send(res).expect("channel closed");
                 });
                 let fut = async move {
-                    mpc(&ch2, &circ2, &inputs2, 0, 1, &p_out)
+                    mpc(&ch2, &circ2, &inputs2, 0, 1, &p_out, None)
                         .await
                         .expect("mpc execution failed")
                 };

--- a/docs/src/protocol.md
+++ b/docs/src/protocol.md
@@ -21,6 +21,7 @@ pub async fn mpc(
     p_eval: usize,
     p_own: usize,
     p_out: &[usize],
+    tmp_dir: Option<&Path>,
 ) -> Result<Vec<bool>, Error>
 ```
 
@@ -33,5 +34,6 @@ Let's look at the parameters in detail:
 - `p_eval`: The party responsible for evaluating the circuit.
 - `p_own`: The index of the current party executing the protocol.
 - `p_out`: The indices of parties who receive the output.
+- `tmp_dir` - An optional directory path where Polytune will store indermediate data if provided. This improves peak memory consumption.
 
 **Usage Scenario**: This is a low-level functionality with both inputs and outputs being vectors of bits. The `mpc` function is used when each party participates in an actual MPC execution, but usually accompanied by higher-level functions to translate data structures to/from their bit-level representations. We provide numerous example usages in the `examples` directory, and in our simulation example, `simulate_mpc`, in the `tests` directory.

--- a/examples/api-integration/Cargo.toml
+++ b/examples/api-integration/Cargo.toml
@@ -17,6 +17,7 @@ reqwest = { version = "0.12.23", features = ["blocking", "json"] }
 schemars = { version = "0.9", features = ["url2"] }
 serde = "1.0.197"
 serde_json = "1.0.143"
+tempfile = "3.21.0"
 tokio = { version = "1.47.1", features = ["macros", "rt", "rt-multi-thread"] }
 tower = { version = "0.5.1", features = ["util"] }
 tower-http = { version = "0.6.6", features = ["fs", "trace"] }

--- a/examples/api-integration/src/main.rs
+++ b/examples/api-integration/src/main.rs
@@ -7,7 +7,7 @@ use aide::{
     swagger::Swagger,
     transform::TransformOperation,
 };
-use anyhow::{Error, anyhow, bail};
+use anyhow::{Context, Error, anyhow, bail};
 use axum::{
     Extension, Json,
     body::Bytes,
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     borrow::BorrowMut,
     collections::HashMap,
-    env::{self},
+    env,
     net::{IpAddr, SocketAddr},
     result::Result,
     str::FromStr,
@@ -335,7 +335,7 @@ async fn execute_mpc(state: MpcState, policy: &Policy) -> Result<Option<Literal>
         &p_out,
         // create a tempdir in ./ and not /tmp because that is often backed by a tmpfs
         // and the files will be in memory and not on the disk
-        Some(tempdir_in("./").expect("Unable to create tempdir").path()),
+        Some(tempdir_in("./").context("Unable to create tempdir")?.path()),
     )
     .await?;
 

--- a/examples/api-integration/src/main.rs
+++ b/examples/api-integration/src/main.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     borrow::BorrowMut,
     collections::HashMap,
-    env,
+    env::{self},
     net::{IpAddr, SocketAddr},
     result::Result,
     str::FromStr,
@@ -32,6 +32,7 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
+use tempfile::tempdir_in;
 use tokio::{
     sync::{
         Mutex,
@@ -332,6 +333,7 @@ async fn execute_mpc(state: MpcState, policy: &Policy) -> Result<Option<Literal>
         0,
         *party,
         &p_out,
+        Some(tempdir_in("./").expect("Unable to create tempdir").path()),
     )
     .await?;
 

--- a/examples/api-integration/src/main.rs
+++ b/examples/api-integration/src/main.rs
@@ -333,6 +333,8 @@ async fn execute_mpc(state: MpcState, policy: &Policy) -> Result<Option<Literal>
         0,
         *party,
         &p_out,
+        // create a tempdir in ./ and not /tmp because that is often backed by a tmpfs
+        // and the files will be in memory and not on the disk
         Some(tempdir_in("./").expect("Unable to create tempdir").path()),
     )
     .await?;

--- a/examples/http-multi-server-channels/src/main.rs
+++ b/examples/http-multi-server-channels/src/main.rs
@@ -69,6 +69,7 @@ async fn main() -> Result<(), Error> {
         0,
         party,
         &p_out,
+        None,
     )
     .await?;
     if !output.is_empty() {

--- a/examples/http-single-server-channels/src/main.rs
+++ b/examples/http-single-server-channels/src/main.rs
@@ -91,6 +91,7 @@ async fn main() {
                 p_eval,
                 party,
                 &p_out,
+                None,
             )
             .await
             .unwrap();

--- a/examples/sql-integration/src/main.rs
+++ b/examples/sql-integration/src/main.rs
@@ -586,7 +586,7 @@ async fn execute_mpc(
     };
 
     // We run the computation using MPC, which might take some time...
-    let output = mpc(&channel, &circuit, &input, 0, *party, &p_out).await?;
+    let output = mpc(&channel, &circuit, &input, 0, *party, &p_out, None).await?;
 
     // ...and now we are done and return the output (if there is any):
     state.lock().await.senders.clear();

--- a/examples/wasm-http-channels/src/lib.rs
+++ b/examples/wasm-http-channels/src/lib.rs
@@ -42,7 +42,7 @@ pub async fn compute(url: String, party: usize, input: i32, range: u32) -> Resul
         .as_bits();
     let p_out = vec![0, 1, 2];
     let channel = HttpChannel::new(url, party).await?;
-    let output = mpc(&channel, &circuit, &input, 0, party, &p_out)
+    let output = mpc(&channel, &circuit, &input, 0, party, &p_out, None)
         .await
         .map_err(|e| format!("MPC computation failed: {e}"))?;
     let output = prg

--- a/src/mpc/fpre.rs
+++ b/src/mpc/fpre.rs
@@ -473,6 +473,7 @@ mod tests {
                     p_eval,
                     p_own,
                     &output_parties,
+                    None
                 );
                 match _mpc(&ctx).await {
                     Ok(res) => {
@@ -497,6 +498,7 @@ mod tests {
             p_eval,
             p_eval,
             output_parties,
+            None
         );
         let eval_result = _mpc(&ctx).await;
         match eval_result {

--- a/src/mpc/fpre.rs
+++ b/src/mpc/fpre.rs
@@ -473,7 +473,7 @@ mod tests {
                     p_eval,
                     p_own,
                     &output_parties,
-                    None
+                    None,
                 );
                 match _mpc(&ctx).await {
                     Ok(res) => {
@@ -498,7 +498,7 @@ mod tests {
             p_eval,
             p_eval,
             output_parties,
-            None
+            None,
         );
         let eval_result = _mpc(&ctx).await;
         match eval_result {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use std::ops::{BitAndAssign, BitXorAssign};
 
+pub(crate) mod maybe_file_buf;
 mod rand_compat;
 
 pub(crate) use rand_compat::RngCompat;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use std::ops::{BitAndAssign, BitXorAssign};
 
-pub(crate) mod maybe_file_buf;
+pub(crate) mod file_or_mem_buf;
 mod rand_compat;
 
 pub(crate) use rand_compat::RngCompat;

--- a/src/utils/maybe_file_buf.rs
+++ b/src/utils/maybe_file_buf.rs
@@ -1,0 +1,200 @@
+use std::{
+    borrow::Cow,
+    fs::File,
+    io::{BufReader, BufWriter, Seek, SeekFrom, Write},
+    path::Path,
+    sync::Arc,
+};
+
+use bincode::Options;
+use serde::{Serialize, de::DeserializeOwned};
+use tempfile::tempfile_in;
+
+/// Abstraction over a chunked buffer backed by a temporary file or in-memory
+///
+/// This type can be used to store intermediate data serialized in chunks in a temporary file.
+/// If the [`MaybeFileBuf::new`] is passed a [`Path`] to a directory, a temporary file will be
+/// created in that directory. Subsequent [`MaybeFileBuf::write_chunk`] calls will serialize the
+/// chunk into the file. Once all data is written, [`MaybeFileBuf::iter`] can be used to create
+/// an iterator for the temporary file (or the in-memory Vec if no directory was provided).
+/// Only ever one of the previously written chunks will be held in memory.
+pub(crate) enum MaybeFileBuf<T> {
+    ChunkedTmpFile { write: BufWriter<Arc<File>> },
+    Memory { data: Vec<T> },
+}
+
+pub(crate) enum MaybeFileBufIter<'a, T> {
+    ChunkedTmpFile {
+        read: BufReader<Arc<File>>,
+        chunk_iter: std::vec::IntoIter<T>,
+    },
+    Memory {
+        iter: std::slice::Iter<'a, T>,
+    },
+}
+
+pub(crate) enum MaybeFileBufChunkIter<'a, T> {
+    ChunkedTmpFile { read: BufReader<Arc<File>> },
+    Memory { iter: std::slice::Chunks<'a, T> },
+}
+
+impl<T> MaybeFileBuf<T> {
+    /// Create an optionally temp file backed buffer.
+    ///
+    /// The capacity is only used for the in-memory buf if `dir` is `None`.
+    pub(crate) fn new(dir: Option<&Path>, capacity: usize) -> std::io::Result<Self> {
+        if let Some(dir) = dir {
+            let f = Arc::new(tempfile_in(dir)?);
+            let write = BufWriter::new(Arc::clone(&f));
+            Ok(Self::ChunkedTmpFile { write })
+        } else {
+            Ok(Self::Memory {
+                data: Vec::with_capacity(capacity),
+            })
+        }
+    }
+
+    /// Create an iterator for the [`MaybeFileBuf`].
+    ///
+    /// For the [`MaybeFileBuf::ChunkedTmpFile`] variant, the matching iterator
+    /// will only read one of the written chunks (+ potentially the default capacity of
+    /// a BufReader) and keep it in memory until it is iterated over. Then the next
+    /// chunk is loaded.
+    pub(crate) fn iter(&mut self) -> std::io::Result<MaybeFileBufIter<'_, T>> {
+        match self {
+            MaybeFileBuf::ChunkedTmpFile { write } => {
+                write.flush()?;
+                let mut file = Arc::clone(write.get_ref());
+                file.rewind()?;
+                let read = BufReader::new(file);
+                Ok(MaybeFileBufIter::ChunkedTmpFile {
+                    read,
+                    chunk_iter: Default::default(),
+                })
+            }
+            MaybeFileBuf::Memory { data } => Ok(MaybeFileBufIter::Memory { iter: data.iter() }),
+        }
+    }
+
+    /// Iterator over the chunks stored in the file or a chunk iterator for the in-memory buf.
+    ///
+    /// The `chunks` parameter is only used in the [`MaybeFileBuf::Memory`] case, otherwise the
+    /// exact chunks that were written to the file by [`MaybeFileBuf::write_chunk`] are returned.
+    pub(crate) fn chunks(&mut self, size: usize) -> std::io::Result<MaybeFileBufChunkIter<'_, T>> {
+        match self {
+            MaybeFileBuf::ChunkedTmpFile { write } => {
+                write.flush()?;
+                let mut file = Arc::clone(write.get_ref());
+                file.rewind()?;
+                let read = BufReader::new(file);
+                Ok(MaybeFileBufChunkIter::ChunkedTmpFile { read })
+            }
+            MaybeFileBuf::Memory { data } => Ok(MaybeFileBufChunkIter::Memory {
+                iter: data.chunks(size),
+            }),
+        }
+    }
+
+    fn bincode() -> impl bincode::Options {
+        bincode::options().allow_trailing_bytes()
+    }
+}
+
+impl<T> Default for MaybeFileBuf<T> {
+    fn default() -> Self {
+        Self::Memory { data: vec![] }
+    }
+}
+
+impl<T: Serialize + Clone> MaybeFileBuf<T> {
+    /// Write a chunk to the temporyr file or in-memory buffer.
+    pub(crate) fn write_chunk(&mut self, chunk: &[T]) -> bincode::Result<()> {
+        match self {
+            MaybeFileBuf::ChunkedTmpFile { write, .. } => {
+                let opts = Self::bincode();
+                opts.serialize_into(write, chunk)?;
+            }
+            MaybeFileBuf::Memory { data } => {
+                data.extend_from_slice(chunk);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'a, T: DeserializeOwned + Clone> Iterator for MaybeFileBufIter<'a, T> {
+    type Item = bincode::Result<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            MaybeFileBufIter::ChunkedTmpFile { read, chunk_iter } => {
+                if let Some(gate) = chunk_iter.next() {
+                    return Some(Ok(gate));
+                }
+                let opts = MaybeFileBuf::<T>::bincode();
+                match opts.deserialize_from::<_, Vec<T>>(read) {
+                    Ok(chunk) => {
+                        *chunk_iter = chunk.into_iter();
+                        self.next()
+                    }
+                    Err(err) => {
+                        if let bincode::ErrorKind::Io(io) = &*err
+                            && std::io::ErrorKind::UnexpectedEof == io.kind()
+                        {
+                            return None;
+                        }
+
+                        Some(Err(err))
+                    }
+                }
+            }
+            MaybeFileBufIter::Memory { iter } => iter.next().map(|e| Ok(e.clone())),
+        }
+    }
+}
+
+// The drop impl ensures that we can create an iterator, and afterwards continue
+// writing to the end of the file and overwrite existing content.
+impl<'a, T> Drop for MaybeFileBufIter<'a, T> {
+    fn drop(&mut self) {
+        if let Self::ChunkedTmpFile { read, .. } = self {
+            read.get_mut()
+                .seek(SeekFrom::End(0))
+                .expect("unable to reset seek position");
+        }
+    }
+}
+
+impl<'a, T: DeserializeOwned + Clone> Iterator for MaybeFileBufChunkIter<'a, T> {
+    type Item = bincode::Result<Cow<'a, [T]>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            MaybeFileBufChunkIter::ChunkedTmpFile { read } => {
+                let opts = MaybeFileBuf::<T>::bincode();
+                match opts.deserialize_from::<_, Vec<T>>(read) {
+                    Ok(chunk) => Some(Ok(Cow::Owned(chunk))),
+                    Err(err) => {
+                        if let bincode::ErrorKind::Io(io) = &*err
+                            && std::io::ErrorKind::UnexpectedEof == io.kind()
+                        {
+                            return None;
+                        }
+                        Some(Err(err))
+                    }
+                }
+            }
+            MaybeFileBufChunkIter::Memory { iter } => iter.next().map(|e| Ok(Cow::Borrowed(e))),
+        }
+    }
+}
+
+impl<'a, T> Drop for MaybeFileBufChunkIter<'a, T> {
+    fn drop(&mut self) {
+        if let Self::ChunkedTmpFile { read, .. } = self {
+            read.get_mut()
+                .seek(SeekFrom::End(0))
+                .expect("unable to reset seek position");
+        }
+    }
+}

--- a/src/utils/maybe_file_buf.rs
+++ b/src/utils/maybe_file_buf.rs
@@ -107,7 +107,7 @@ impl<T> Default for MaybeFileBuf<T> {
 }
 
 impl<T: Serialize + Clone> MaybeFileBuf<T> {
-    /// Write a chunk to the temporyr file or in-memory buffer.
+    /// Write a chunk to the temporary file or in-memory buffer.
     pub(crate) fn write_chunk(&mut self, chunk: &[T]) -> bincode::Result<()> {
         match self {
             MaybeFileBuf::ChunkedTmpFile { write, .. } => {
@@ -154,7 +154,7 @@ impl<'a, T: DeserializeOwned + Clone> Iterator for MaybeFileBufIter<'a, T> {
 }
 
 // The drop impl ensures that we can create an iterator, and afterwards continue
-// writing to the end of the file and overwrite existing content.
+// writing to the end of the file and don't overwrite existing content.
 impl<'a, T> Drop for MaybeFileBufIter<'a, T> {
     fn drop(&mut self) {
         if let Self::ChunkedTmpFile { read, .. } = self {

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -4,6 +4,7 @@ use garble_lang::{
     register_circuit::Circuit as RegisterCircuit,
 };
 use polytune::{Error, channel, mpc};
+use tempfile::tempdir;
 
 /// Simulates the multi party computation with the given inputs and party 0 as the evaluator.
 fn simulate_mpc(
@@ -40,7 +41,17 @@ async fn simulate_mpc_async(
         let inputs = inputs.to_vec();
         let output_parties = output_parties.to_vec();
         computation.spawn(async move {
-            match mpc(&channel, &circuit, &inputs, p_eval, p_own, &output_parties).await {
+            match mpc(
+                &channel,
+                &circuit,
+                &inputs,
+                p_eval,
+                p_own,
+                &output_parties,
+                Some(tempdir().unwrap().path()),
+            )
+            .await
+            {
                 Ok(res) => {
                     println!(
                         "Party {p_own} sent {:.2}MB of messages",
@@ -62,6 +73,7 @@ async fn simulate_mpc_async(
         p_eval,
         p_eval,
         output_parties,
+        Some(tempdir().unwrap().path()),
     )
     .await;
     match eval_result {


### PR DESCRIPTION
To reduce peak memory consumption (#113) this PR adds the optional to provide a directory to the `mpc` function. When provided, intermediate data such as `random_shares`, `auth_bit`, `garbled_gates`, etc. will be written to a temporary file in chunks. When needed, these files are read chunk by chunk. This improves peak memory consumption significantly, as we never have to hold the relevant data in memory completely, but only parts of it.

This PR reduces the peak memory consumption of the large join benchmark from ~25 GB to <4 GB.

stacked on top of #202 