### PR TITLE
Add more metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ edition = "2024"
 rust-version = "1.88.0"
 description = "Maliciously-Secure Multi-Party Computation (MPC) Engine using Authenticated Garbling"
 repository = "https://github.com/sine-fdn/polytune/"
+homepage = "https://polytune.org/"
 license = "MIT"
-categories = ["cryptography"]
+categories = ["cryptography", "security"]
 keywords = [
     "secure-computation",
     "garbled-circuits",
@@ -26,6 +27,11 @@ keywords = [
 # executes benches in various modules under `benches/`. Those modules should
 # not be automatically detected as separate benchmarks.
 autobenches = false
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+    "--generate-link-to-definition",
+]
 
 [lib]
 bench = false


### PR DESCRIPTION
This also enable the [generate-link-to-definition](https://doc.rust-lang.org/beta/rustdoc/unstable-features.html#--generate-link-to-definition-generate-links-on-types-in-source-code) unstable feature of rustdoc for docs.rs. Since docs.rs builds the documentation with nightly, we can use this feature. Its really handy when navigating the source code of a crate on docs.rs.

closes #151 