### PR TITLE
CI: Set rustflags to only +avx2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_LOG: debug
+  RUSTFLAGS: "-C target-feature=+avx2"
 
 jobs:
   lint:
@@ -94,6 +95,10 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
+      # No avx2 on apple ARM
+      - name: Set RUSTFLAGS for macOS
+        if: runner.os == 'macOS'
+        run: echo "RUSTFLAGS=" >> $GITHUB_ENV
       - run: cargo test --release
 
   test-examples:


### PR DESCRIPTION
This should resolve the illegal instruction errors we had in CI as we previously always built with target-cpu=native