### PR TITLE
http-server: compile with no RUSTFLAGS

### DIFF
--- a/.github/workflows/push_http_server_image.yml
+++ b/.github/workflows/push_http_server_image.yml
@@ -4,13 +4,16 @@ on:
   push:
     branches: [ "main" ]
 
+env:
+  # Reset the RUSTFLAGS so we don't compile for target-cpu=native
+  RUSTFLAGS: ""
+
 jobs:
   build-and-push-http-server:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
If the CI runner that compiles the http-server image has a different instruction set than the host that later runs the server, this can result in a SIGILL. This happened as by default the RUSTFLAGS configured in .cargo/config.toml were used.

This commit fixes that by explicitly setting the RUSTFLAGS to "". The server will still be able to use aes and avx2 instructions for encryption and bitmatrix transpose, as these use runtime feature detection.