### PR TITLE
http-server: Fix CI compilation for native CPU

### DIFF
--- a/.github/workflows/push_http_server_image.yml
+++ b/.github/workflows/push_http_server_image.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches: [ "main" ]
 
-env:
-  # Reset the RUSTFLAGS so we don't compile for target-cpu=native
-  RUSTFLAGS: ""
-
 jobs:
   build-and-push-http-server:
     runs-on: ubuntu-latest

--- a/crates/polytune-http-server/Dockerfile
+++ b/crates/polytune-http-server/Dockerfile
@@ -1,6 +1,7 @@
 FROM rust:1.91 AS builder
 WORKDIR /usr/src/polytune
 COPY . .
+ARG RUSTFLAGS=""
 RUN cargo build --release --package polytune-http-server
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
It seems the fix of https://github.com/sine-fdn/polytune/pull/277 did not work as the RUSTFLAGS env variable in the CI job was not passed into the docker build context.