### PR TITLE
http-server: Fix jwt-claims parsing

### DIFF
--- a/crates/polytune-http-server/src/bin/polytune-http-server.rs
+++ b/crates/polytune-http-server/src/bin/polytune-http-server.rs
@@ -51,7 +51,7 @@ struct Cli {
     ///
     /// POLYTUNE_JWT_CLAIMS='{"roles": ["TEST_ROLE"]}' polytune-http-server
     #[arg(long, requires = "jwt_key", env = "POLYTUNE_JWT_CLAIMS")]
-    jwt_claims: Option<serde_json::Value>,
+    jwt_claims: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 #[tokio::main]

--- a/crates/polytune-http-server/src/policy_client.rs
+++ b/crates/polytune-http-server/src/policy_client.rs
@@ -65,7 +65,7 @@ struct JwtClaims {
     iat: u64,
     exp: u64,
     #[serde(flatten)]
-    additional_claims: Option<serde_json::Value>,
+    additional_claims: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 impl JwtData {

--- a/crates/polytune-http-server/src/server.rs
+++ b/crates/polytune-http-server/src/server.rs
@@ -47,7 +47,7 @@ pub struct JwtConf {
     /// PEM encoded ECDSA key in PKCS#8 form for creating JWTs that are added to requests.
     pub key: EncodingKey,
     /// Additional claims to add to the signed JWTs encoded as json object.
-    pub claims: Option<serde_json::Value>,
+    pub claims: Option<serde_json::Map<String, serde_json::Value>>,
     /// The JWT `iss` claim to use for signed JWTs
     pub iss: String,
     /// The JWT `exp` expiry in seconds from creation claim to use for signed JWTs.

--- a/crates/polytune-http-server/tests/cli.rs
+++ b/crates/polytune-http-server/tests/cli.rs
@@ -31,6 +31,7 @@ fn test_and_profile_server() {
     let heaptrack_profiling = env::var("POLYTUNE_TEST_HEAPTRACK").is_ok();
     let samply_profiling = env::var("POLYTUNE_TEST_SAMPLY").is_ok();
     let polytune_bin = PathBuf::from(env!("CARGO_BIN_EXE_polytune-http-server"));
+    let crate_dir: PathBuf = env!("CARGO_MANIFEST_DIR").parse().unwrap();
 
     #[cfg(not(debug_assertions))]
     if samply_profiling || heaptrack_profiling {
@@ -51,6 +52,16 @@ fn test_and_profile_server() {
     } else {
         vec![]
     };
+    let jwt_key_arg = format!(
+        "--jwt-key={}",
+        crate_dir.join("test_key/test-private.pem").display()
+    );
+    common_args.extend([
+        &jwt_key_arg,
+        "--jwt-iss=polytune",
+        "--jwt-exp=1",
+        r#"--jwt-claims={"roles": ["TEST_ROLE"]}"#,
+    ]);
 
     if use_big_input {
         common_args.push("--tmp-dir=.");
@@ -130,7 +141,6 @@ fn test_and_profile_server() {
         }
     });
 
-    let crate_dir: PathBuf = env!("CARGO_MANIFEST_DIR").parse().unwrap();
     let (pol0, pol1) = if use_big_input {
         (
             fs::read_to_string(crate_dir.join("policies/policy0-big.json")).unwrap(),

--- a/crates/polytune-http-server/tests/server.rs
+++ b/crates/polytune-http-server/tests/server.rs
@@ -53,7 +53,12 @@ async fn concurrent_eval() {
             tmp_dir: Some(current_dir().expect("current dir")),
             jwt_conf: Some(JwtConf {
                 key,
-                claims: Some(serde_json::json!({"roles":["TEST_ROLE"]})),
+                claims: Some(
+                    serde_json::json!({"roles":["TEST_ROLE"]})
+                        .as_object()
+                        .expect("json is object")
+                        .clone(),
+                ),
                 iss: "polytune".to_string(),
                 exp: 300,
             }),


### PR DESCRIPTION
The --jwt-claims parsing always resulted in a string instead of an object.