### PR TITLE
http-server: add health check route

### DIFF
--- a/crates/polytune-http-server/README.md
+++ b/crates/polytune-http-server/README.md
@@ -2,7 +2,7 @@
 
 This crate implements a full-fledged MPC server which can receive requests containing a program specified as a Garble program, coordinate with multiple instances of this server, execute the provided program securely using Polytune, and return the result.
 
-The MPC program as well as any configuration necessary is specified using a JSON configuration that is provided via an API call to the `polytune-server`.
+The MPC program as well as any configuration necessary is specified using a JSON configuration that is provided via an API call to the `polytune-http-server`.
 
 ## How to Deploy the Engine
 

--- a/crates/polytune-http-server/src/api.rs
+++ b/crates/polytune-http-server/src/api.rs
@@ -142,6 +142,17 @@ pub(crate) async fn msg(
         .map_err(ApiError::from)
 }
 
+pub fn health_docs(t: TransformOperation) -> TransformOperation {
+    t.id("health")
+        .description("Health check. Returns a status code 200 if the service is running.")
+}
+
+pub(crate) async fn health(State(state): State<PolytuneState>) {
+    // We try to get the state handles lock. If for some reason the service is deadlocked on
+    // this lock, the /health call will timeout and fail
+    let _ = state.state_handles.read().await;
+}
+
 #[derive(OperationIo, Serialize)]
 #[serde(tag = "type", content = "details")]
 #[aide(output)]

--- a/crates/polytune-http-server/src/router.rs
+++ b/crates/polytune-http-server/src/router.rs
@@ -1,7 +1,7 @@
 use aide::{
     axum::{
         ApiRouter,
-        routing::{get, post_with},
+        routing::{get, get_with, post_with},
     },
     swagger::Swagger,
 };
@@ -20,6 +20,7 @@ pub(crate) fn router(state: PolytuneState) -> ApiRouter {
     ApiRouter::new()
         // to start an MPC session as a leader:
         .api_route("/schedule", post_with(api::schedule, api::schedule_docs))
+        .api_route("/health", get_with(api::health, api::health_docs))
         .route("/validate", axum::routing::post(api::validate))
         // to kick off an MPC session:
         .route("/run", axum::routing::post(api::run))


### PR DESCRIPTION
Adds a `/health` route that returns a 200 status code if policies can be scheduled.