### PR TITLE
wasm-http example: set RUSTFLAGS in buid.sh

### DIFF
--- a/examples/wasm-http-channels/build.sh
+++ b/examples/wasm-http-channels/build.sh
@@ -2,5 +2,8 @@
 
 set -ex
 
+# See https://docs.rs/getrandom/0.3.3/getrandom/#webassembly-support
+export RUSTFLAGS='--cfg getrandom_backend="wasm_js"'
+
 wasm-pack build --target web
 python3 -m http.server 9000 --bind 127.0.0.1


### PR DESCRIPTION
The getrandom version we're using requires a cfg variable to be set during compilation for wasm support. This was already done in CI but not in the build.sh script.
See https://docs.rs/getrandom/0.3.3/getrandom/#webassembly-support