### PR TITLE
http-server: Add jemalloc and memory logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,6 +1963,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,6 +2167,8 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tower",
  "tower-http",
@@ -3341,6 +3349,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/crates/polytune-http-server/Cargo.toml
+++ b/crates/polytune-http-server/Cargo.toml
@@ -36,6 +36,10 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 url = { version = "2.5.7", features = ["serde"] }
 uuid = { version = "1.18.1", features = ["serde"] }
 
+[target.'cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))'.dependencies]
+tikv-jemallocator = "0.6.1"
+tikv-jemalloc-ctl = { version = "0.6.1", features = ["stats"] }
+
 [dev-dependencies]
 futures = "0.3.31"
 uuid = { version = "1.18.1", features = ["v4"] }

--- a/crates/polytune-http-server/README.md
+++ b/crates/polytune-http-server/README.md
@@ -95,10 +95,14 @@ Options:
           [env: POLYTUNE_JWT_CLAIMS=]
 ```
 
-## OpenAPI spec
+## OpenAPI Spec
 
 The server provides an OpenAPI spec at `/api.json` and a Swagger UI for the spec at `/swagger`.
 
 ## Logging
 
 The logging output of the server can be configured using the `POLYTUNE_LOG` environment variable using an [`EnvFilter` directive](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html).
+
+## Concurrency and Memory Consumption
+
+Polytune HTTP server exposes a `concurrency` parameter, that controls how many concurrent policy evaluations this instance can be the leader of. This parameter needs to be tuned based on available RAM the server is running on and the Garble programs that are executed. To help estimate the memory needs of the service and the concurrency value, Polytune will print its current memory consumption regularly as a debug message. To view this message, set the `POLYTUNE_LOG` env variable to `debug` (this displays all debug variables) or to `polytune_http_server::memory_tracking=debug` to just receive memory tracking messages. This memory tracking is only available on the `x86_64-unknown-linux-gnu` target, i.e. `x86_64` architecture on Linux with glibc. If you're using the provided docker image, this is enabled.


### PR DESCRIPTION
This commit adds the jemalloc allocator on the x86_64-unknown-linux-gnu platform and regular debug messages that print the current memory consumpption.