### PR TITLE
CI: Add cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,16 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "weekly"
+      day: "wednesday"
 
   - package-ecosystem: "github-actions"
     directory: ".github/workflows/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "weekly"
+      day: "wednesday"


### PR DESCRIPTION
Adding a cooldown to dependency updates can reduce the risk that we fall victim to a supply chain attacks due to a compromised dependency. In many cases, there is a somewhat short window of opportunity after a malicious version has been published and this is uncovered. By adding, a cooldown, we hopefully fall outside of this window of opportunity of the attacker.


I have been delaying merging dependabots updates for some time due to this reason, and after reading [this blog post](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns) and learning of the cooldown option, I think it makes sense to explicitly do this. Note that the cooldown apparently does not include updates with a security advisory.