### PR TITLE
polytune: use Block type consistently

### DIFF
--- a/src/bench_reexports.rs
+++ b/src/bench_reexports.rs
@@ -18,7 +18,7 @@ pub async fn kos_ot_sender(
     deltas: &[Block],
     p_to: usize,
     shared_rand: &mut ChaCha20Rng,
-) -> Result<Vec<u128>, Error> {
+) -> Result<Vec<Block>, Error> {
     ot::kos_ot_sender(channel, deltas, p_to, shared_rand).await
 }
 
@@ -27,6 +27,6 @@ pub async fn kos_ot_receiver(
     bs: &[bool],
     p_to: usize,
     shared_rand: &mut ChaCha20Rng,
-) -> Result<Vec<u128>, Error> {
+) -> Result<Vec<Block>, Error> {
     ot::kos_ot_receiver(channel, bs, p_to, shared_rand).await
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -160,6 +160,12 @@ impl Block {
         }
         BitIter { blk: *self, idx: 0 }
     }
+
+    /// Computes self * b, where b is `bool` in constant time.
+    #[inline]
+    pub fn const_mul(&self, b: bool) -> Block {
+        Block::conditional_select(&Block::ZERO, self, Choice::from(u8::from(b)))
+    }
 }
 
 // Implement standard operators for more ergonomic usage

--- a/src/mpc/fpre.rs
+++ b/src/mpc/fpre.rs
@@ -91,7 +91,7 @@ pub(crate) async fn fpre(channel: &(impl Channel + Send), parties: usize) -> Res
         let mut keys = vec![];
         for i in 0..parties {
             bits.push(random());
-            keys.push(vec![Key(0); parties]);
+            keys.push(vec![Key::default(); parties]);
             for (j, key) in keys[i].iter_mut().enumerate() {
                 if i != j {
                     *key = Key(random());
@@ -99,7 +99,7 @@ pub(crate) async fn fpre(channel: &(impl Channel + Send), parties: usize) -> Res
             }
         }
         for i in 0..parties {
-            let mut mac_and_key = vec![(Mac(0), Key(0)); parties];
+            let mut mac_and_key = vec![(Mac::default(), Key::default()); parties];
             for j in 0..parties {
                 if i != j {
                     let mac = keys[j][i] ^ (bits[i] & deltas[j]);
@@ -152,7 +152,7 @@ pub(crate) async fn fpre(channel: &(impl Channel + Send), parties: usize) -> Res
         for (i, (a, b)) in share.iter().enumerate() {
             for (Share(bit, Auth(macs_i)), round) in [(a, 0), (b, 1)] {
                 for (j, (mac_i, _)) in macs_i.iter().enumerate() {
-                    if *mac_i != Mac(0) {
+                    if *mac_i != Mac::default() {
                         // Added when removed Option
                         let (a, b) = &share[j];
                         let Share(_, Auth(keys_j)) = if round == 0 { a } else { b };
@@ -193,7 +193,7 @@ pub(crate) async fn fpre(channel: &(impl Channel + Send), parties: usize) -> Res
                 current_share ^= share;
                 share
             };
-            keys.push(vec![Key(0); parties]);
+            keys.push(vec![Key::default(); parties]);
             for (j, key) in keys[i].iter_mut().enumerate() {
                 if i != j {
                     *key = Key(random());
@@ -201,7 +201,7 @@ pub(crate) async fn fpre(channel: &(impl Channel + Send), parties: usize) -> Res
             }
         }
         for i in 0..parties {
-            let mut mac_and_key = vec![(Mac(0), Key(0)); parties];
+            let mut mac_and_key = vec![(Mac::default(), Key::default()); parties];
             for j in 0..parties {
                 if i != j {
                     let mac = keys[j][i] ^ (bits[i] & deltas[j]);
@@ -362,7 +362,10 @@ mod tests {
                 assert_eq!(mac_s3, key_s3 ^ (s3 & delta_a));
             } else if i == 1 {
                 // corrupted (r1 XOR s1) AND (r2 XOR s2):
-                let auth_r1_corrupted = Share(!r1, Auth(vec![(Mac(0), Key(0)), (mac_r1, key_s1)]));
+                let auth_r1_corrupted = Share(
+                    !r1,
+                    Auth(vec![(Mac::default(), Key::default()), (mac_r1, key_s1)]),
+                );
                 send_to(
                     &a,
                     fpre_party,
@@ -384,7 +387,10 @@ mod tests {
                 let mac_r1_corrupted = key_r1 ^ (!r1 & delta_b);
                 let auth_r1_corrupted = Share(
                     !r1,
-                    Auth(vec![(Mac(0), Key(0)), (mac_r1_corrupted, key_s1)]),
+                    Auth(vec![
+                        (Mac::default(), Key::default()),
+                        (mac_r1_corrupted, key_s1),
+                    ]),
                 );
                 send_to(
                     &a,

--- a/src/mpc/garble.rs
+++ b/src/mpc/garble.rs
@@ -70,8 +70,8 @@ fn key_and_nonce(
     }: &GarblingKey,
 ) -> (Key, Nonce) {
     let mut key = [0; 32];
-    key[..16].copy_from_slice(&label_x.0.to_be_bytes());
-    key[16..].copy_from_slice(&label_y.0.to_be_bytes());
+    key[..16].copy_from_slice(label_x.0.as_bytes());
+    key[16..].copy_from_slice(label_y.0.as_bytes());
     let mut nonce = [0; 12];
     nonce[..8].copy_from_slice(&(*w as u64).to_be_bytes());
     nonce[8] = *row;
@@ -82,9 +82,9 @@ fn key_and_nonce(
 mod tests {
     use rand::random_range;
 
-    use crate::{
-        mpc::data_types::{Label, Mac},
-        mpc::garble::{GarblingKey, decrypt, encrypt},
+    use crate::mpc::{
+        data_types::{Label, Mac},
+        garble::{GarblingKey, decrypt, encrypt},
     };
 
     #[test]
@@ -99,7 +99,7 @@ mod tests {
         };
         let triple = (
             random(),
-            vec![Mac(random()), Mac(0), Mac(random())],
+            vec![Mac(random()), Mac::default(), Mac(random())],
             Label(random()),
         );
         let encrypted = encrypt(&key, triple.clone()).unwrap();

--- a/src/ot.rs
+++ b/src/ot.rs
@@ -5,22 +5,12 @@ use crate::{block::Block, channel::Channel, crypto::AesRng, mpc::faand::Error};
 
 use rand_chacha::ChaCha20Rng;
 
-/// Transform Block to u128
-pub(crate) fn block_to_u128(inp: Block) -> u128 {
-    let array: [u8; 16] = inp.into();
-    let mut value = 0;
-    for &byte in array.iter() {
-        value = (value << 8) | byte as u128;
-    }
-    value
-}
-
 pub(crate) async fn kos_ot_sender(
     channel: &impl Channel,
     deltas: &[Block],
     p_to: usize,
     shared_rand: &mut ChaCha20Rng,
-) -> Result<Vec<u128>, Error> {
+) -> Result<Vec<Block>, Error> {
     let mut rng = AesRng::new();
     let mut ot = ot_core::KosSender::init(channel, &mut rng, p_to, shared_rand).await?;
 
@@ -28,8 +18,8 @@ pub(crate) async fn kos_ot_sender(
         .send_correlated(channel, deltas, &mut rng, p_to, shared_rand)
         .await?;
     let mut sender_out = vec![];
-    for (i, _) in sender_out_block.iter() {
-        sender_out.push(block_to_u128(*i));
+    for (i, _) in sender_out_block.into_iter() {
+        sender_out.push(i);
     }
     Ok(sender_out)
 }
@@ -39,16 +29,12 @@ pub(crate) async fn kos_ot_receiver(
     bs: &[bool],
     p_to: usize,
     shared_rand: &mut ChaCha20Rng,
-) -> Result<Vec<u128>, Error> {
+) -> Result<Vec<Block>, Error> {
     let mut rng = AesRng::new();
     let mut ot = ot_core::KosReceiver::init(channel, &mut rng, p_to, shared_rand).await?;
 
-    let recver_out_block = ot
+    let recver_out = ot
         .recv_correlated(channel, bs, &mut rng, p_to, shared_rand)
         .await?;
-    let mut recver_out = vec![];
-    for i in recver_out_block.iter() {
-        recver_out.push(block_to_u128(*i));
-    }
     Ok(recver_out)
 }


### PR DESCRIPTION
closes #210

This also fixes some cases where there were potential timing side-channel issues by introducing a `Block::const_mul` method that multiplies a Block with a bool in constant time by using the conditional select implementation.

This does not really change performance, as Block was already used in the performance critical parts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated public API to return Block values instead of u128 primitives for oblivious transfer and cryptographic operations.
  * Hash function signatures changed to operate with Block types instead of numeric primitives.
  * Data structure fields refactored throughout to use Block-based cryptographic representations for improved type consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->