### PR TITLE
fix: breakage due to update in `block-cyphers`

### DIFF
--- a/src/crypto/aes_rng.rs
+++ b/src/crypto/aes_rng.rs
@@ -194,7 +194,7 @@ impl From<AesRngCore> for AesRng {
 /// must not influence correctness or network messages.
 // https://github.com/RustCrypto/block-ciphers/blob/4da9b802de52a3326fdc74d559caddd57042fed2/aes/src/ni.rs#L43
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub(crate) const AES_PAR_BLOCKS: usize = 9;
+pub(crate) const AES_PAR_BLOCKS: usize = 8;
 #[cfg(target_arch = "aarch64")]
 // https://github.com/RustCrypto/block-ciphers/blob/4da9b802de52a3326fdc74d559caddd57042fed2/aes/src/armv8.rs#L32
 pub(crate) const AES_PAR_BLOCKS: usize = 21;


### PR DESCRIPTION
`block-cyphers` changed `par_size` from `9` to `8` recently, causing builds to break.