### PR TITLE
Fix: use supported clock in WASM MPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2231,6 +2231,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "web-time",
  "wide",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ tempfile = "3.27.0"
 thiserror = "2.0.18"
 tokio = { version = "1.49.0", features = ["macros", "sync", "time"] }
 tracing = "0.1.44"
+web-time = "1.1"
 wide = { version = "1.4.0", features = ["serde"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/mpc/protocol.rs
+++ b/src/mpc/protocol.rs
@@ -36,7 +36,6 @@ use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::iter;
 use std::path::Path;
-use std::time::Instant;
 use std::{cmp, sync::Mutex};
 
 use futures_util::future::{try_join, try_join_all};
@@ -45,6 +44,7 @@ use garble_lang::register_circuit::{And, Circuit, Input, Not, Op, Reg, Xor};
 use rand::random;
 use rand_chacha::ChaCha20Rng;
 use tracing::{Level, debug, info, instrument};
+use web_time::Instant;
 
 use crate::block::Block;
 use crate::utils::file_or_mem_buf::FileOrMemBuf;


### PR DESCRIPTION
As was pointed out in PR #548 by @nicola, the WASM example was failing due to calling `std::time::Instant` when running MPC on `wasm32`. In the discussion in the thread at PR #548, we opted for using a supported clock instead of avoiding the use altogether. This is due to the fact that the dependency cost of `web-time` is minimal in our case and we prefer keeping the functionality with minor changes. 

Thank you very much for pointing out the issue, @nicola!

This PR closes #548 as well.
